### PR TITLE
feat: 토큰 재발급 기능 구현

### DIFF
--- a/NBTI/src/main/java/com/dao/nbti/common/auth/application/controller/AuthController.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/auth/application/controller/AuthController.java
@@ -2,17 +2,15 @@ package com.dao.nbti.common.auth.application.controller;
 
 import com.dao.nbti.common.auth.application.dto.LoginRequest;
 import com.dao.nbti.common.auth.application.dto.LoginResponse;
+import com.dao.nbti.common.auth.application.dto.TokenResponse;
 import com.dao.nbti.common.auth.application.service.AuthService;
 import com.dao.nbti.common.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.Duration;
 
@@ -28,6 +26,21 @@ public class AuthController {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .body(ApiResponse.success(response));
+    }
+
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<TokenResponse>> refreshToken(
+            @CookieValue(name = "refreshToken", required = false) String refreshToken
+    ) {
+        if (refreshToken == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build(); // refreshToken이 없으면 401 반환
+        }
+        TokenResponse tokenResponse = authService.refreshToken(refreshToken);
+        ResponseCookie cookie = createRefreshTokenCookie(tokenResponse.getRefreshToken());  // refreshToken 쿠키 생성
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(ApiResponse.success(tokenResponse));
     }
 
     private ResponseCookie createRefreshTokenCookie(String refreshToken) {

--- a/NBTI/src/main/java/com/dao/nbti/common/auth/application/dto/TokenResponse.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/auth/application/dto/TokenResponse.java
@@ -1,0 +1,11 @@
+package com.dao.nbti.common.auth.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/NBTI/src/main/java/com/dao/nbti/user/application/dto/UserCreateRequest.java
+++ b/NBTI/src/main/java/com/dao/nbti/user/application/dto/UserCreateRequest.java
@@ -17,7 +17,7 @@ import java.util.Date;
 @ToString
 public class UserCreateRequest {
     @NotBlank
-    @Size(min = 8)
+    @Size(min = 6)
     @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "아이디는 영문 또는 숫자만 입력할 수 있습니다")
     private String accountId;
 

--- a/NBTI/src/main/java/com/dao/nbti/user/domain/repository/UserRepository.java
+++ b/NBTI/src/main/java/com/dao/nbti/user/domain/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
     Optional<User> findByAccountIdAndDeletedAtIsNull(String accountId);
 
+    Optional<User> findByUserIdAndDeletedAtIsNull(Integer userId);
+
 }

--- a/NBTI/src/test/java/com/dao/nbti/common/auth/application/service/AuthServiceTest.java
+++ b/NBTI/src/test/java/com/dao/nbti/common/auth/application/service/AuthServiceTest.java
@@ -1,0 +1,156 @@
+package com.dao.nbti.common.auth.application.service;
+
+import com.dao.nbti.common.auth.application.dto.LoginRequest;
+import com.dao.nbti.common.auth.application.dto.LoginResponse;
+import com.dao.nbti.common.auth.application.dto.TokenResponse;
+import com.dao.nbti.common.auth.domain.aggregate.RefreshToken;
+import com.dao.nbti.common.jwt.JwtTokenProvider;
+import com.dao.nbti.user.domain.aggregate.Authority;
+import com.dao.nbti.user.domain.aggregate.User;
+import com.dao.nbti.user.domain.repository.UserRepository;
+import com.dao.nbti.user.exception.UserException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    private RedisTemplate<String, RefreshToken> redisTemplate;
+    @InjectMocks
+    private AuthService authService;
+
+    private User user;
+    private final int userId = 1;
+    private final String accountId = "userId0001";
+    private final String password = "encodedPassword";
+    private final String accessToken = "accessToken";
+    private final String refreshToken = "refreshToken";
+    private final Authority authority = Authority.USER;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .userId(userId)
+                .accountId(accountId)
+                .password(password)
+                .authority(authority)
+                .build();
+    }
+
+    @Test
+    void login() {
+        LoginRequest loginRequest = new LoginRequest(accountId,password);
+        ValueOperations<String, RefreshToken> valueOperations = mock(ValueOperations.class);
+
+        when(userRepository.findByAccountIdAndDeletedAtIsNull(loginRequest.getAccountId())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(loginRequest.getPassword(),user.getPassword())).thenReturn(true);
+        when(jwtTokenProvider.createToken(any(), any())).thenReturn(accessToken);
+        when(jwtTokenProvider.createRefreshToken(any(), any())).thenReturn(refreshToken);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        LoginResponse loginResponse = authService.login(loginRequest);
+
+        assertEquals(accessToken,loginResponse.getAccessToken());
+        assertEquals(refreshToken, loginResponse.getRefreshToken());
+        assertEquals(authority, loginResponse.getAuthority());
+    }
+
+    @Test
+    void login_password_discord(){
+        LoginRequest loginRequest = new LoginRequest(accountId, "discord");
+
+        when(userRepository.findByAccountIdAndDeletedAtIsNull(accountId)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(loginRequest.getPassword(),user.getPassword())).thenReturn(false);
+
+        assertThrows(UserException.class, () -> authService.login(loginRequest));
+    }
+
+    @Test
+    void login_accountId_discord(){
+        LoginRequest loginRequest = new LoginRequest("discord",password);
+        when(userRepository.findByAccountIdAndDeletedAtIsNull(loginRequest.getAccountId())).thenReturn(Optional.empty());
+
+        assertThrows(UserException.class, () -> authService.login(loginRequest));
+    }
+
+
+    @Test
+    void refreshToken() {
+        String providedRefreshToken = "refreshToken";
+        RefreshToken storedRefreshToken = RefreshToken.builder()
+                        .token(refreshToken)
+                        .build();
+        ValueOperations<String, RefreshToken> valueOperations = mock(ValueOperations.class);
+
+        when(jwtTokenProvider.validateToken(providedRefreshToken)).thenReturn(true);
+        when(jwtTokenProvider.getUsernameFromJWT(providedRefreshToken)).thenReturn(String.valueOf(userId));
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(String.valueOf(userId))).thenReturn(storedRefreshToken);
+        when(userRepository.findByUserIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+        when(jwtTokenProvider.createToken(any(), any())).thenReturn(accessToken);
+        when(jwtTokenProvider.createRefreshToken(String.valueOf(userId), user.getAuthority().name())).thenReturn(refreshToken);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        TokenResponse tokenResponse =  authService.refreshToken(providedRefreshToken);
+        assertEquals(tokenResponse.getAccessToken(), accessToken);
+        assertEquals(tokenResponse.getRefreshToken(),refreshToken);
+    }
+
+    @Test
+    void refreshToken_not_found(){
+        String providedRefreshToken = "refreshToken";
+        ValueOperations<String, RefreshToken> valueOperations = mock(ValueOperations.class);
+        String unknownId = "unknown";
+
+        when(jwtTokenProvider.validateToken(providedRefreshToken)).thenReturn(true);
+        when(jwtTokenProvider.getUsernameFromJWT(providedRefreshToken)).thenReturn(unknownId);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(unknownId)).thenReturn(null);
+
+        assertThrows(BadCredentialsException.class, () ->authService.refreshToken(providedRefreshToken));
+    }
+
+    @Test
+    void refreshToken_token_discord(){
+        String providedRefreshToken = "refreshToken";
+        ValueOperations<String, RefreshToken> valueOperations = mock(ValueOperations.class);
+        RefreshToken storedRefreshToken = RefreshToken.builder()
+                .token(refreshToken)
+                .build();
+        String discordToken = "discord";
+        RefreshToken discordRefreshToken = RefreshToken.builder()
+                .token(discordToken)
+                .build();
+
+        when(jwtTokenProvider.validateToken(providedRefreshToken)).thenReturn(true);
+        when(jwtTokenProvider.getUsernameFromJWT(providedRefreshToken)).thenReturn(String.valueOf(userId));
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(String.valueOf(userId))).thenReturn(discordRefreshToken);
+
+
+        assertThrows(BadCredentialsException.class, () ->authService.refreshToken(providedRefreshToken));
+    }
+
+}


### PR DESCRIPTION
closes #51

📌 개요
사용자가 refreshToken을 이용하여 엔드포인트를 통해 토큰을 재발급 받을 수 있다.

🔨 주요 변경 사항
AuthController.refreshToken 메소드 구현
AuthService.refreshToken 메소드 구현
테스트 코드 작성

✅ 리뷰 요청 사항
컨벤션 준수 및 테스트코드 올바른지

⭐ 관련 이슈
#51
