### PR TITLE
feat: 문제 수정, 삭제 기능 구현

### DIFF
--- a/NBTI/src/main/java/com/dao/nbti/problem/application/controller/AdminProblemController.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/application/controller/AdminProblemController.java
@@ -5,6 +5,7 @@ import com.dao.nbti.common.exception.ErrorCode;
 import com.dao.nbti.problem.application.dto.request.ProblemCreateRequest;
 import com.dao.nbti.problem.application.dto.request.ProblemSearchRequest;
 import com.dao.nbti.problem.application.dto.request.ProblemUpdateRequest;
+import com.dao.nbti.problem.application.dto.response.ProblemDeleteResponse;
 import com.dao.nbti.problem.application.dto.response.ProblemDetailsResponse;
 import com.dao.nbti.problem.application.dto.response.ProblemListResponse;
 import com.dao.nbti.problem.application.service.AdminProblemService;
@@ -50,6 +51,13 @@ public class AdminProblemController {
     public ResponseEntity<ApiResponse<ProblemDetailsResponse>> updateProblem(@Valid @RequestBody ProblemUpdateRequest problemUpdateRequest, @PathVariable int problemId) {
 
         return ResponseEntity.ok(ApiResponse.success(adminProblemService.updateProblem(problemUpdateRequest, problemId)));
+    }
+
+    @DeleteMapping("/{problemId}")
+    @Operation(summary = "문제 삭제", description = "관리자가 서비스에 등록된 문제를 삭제합니다.")
+    public ResponseEntity<ApiResponse<ProblemDeleteResponse>> deleteProblem(@PathVariable int problemId) {
+
+        return ResponseEntity.ok(ApiResponse.success(adminProblemService.deleteProblem(problemId)));
     }
 
     @ExceptionHandler(ProblemException.class)

--- a/NBTI/src/main/java/com/dao/nbti/problem/application/controller/AdminProblemController.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/application/controller/AdminProblemController.java
@@ -3,6 +3,7 @@ package com.dao.nbti.problem.application.controller;
 import com.dao.nbti.common.dto.ApiResponse;
 import com.dao.nbti.problem.application.dto.request.ProblemCreateRequest;
 import com.dao.nbti.problem.application.dto.request.ProblemSearchRequest;
+import com.dao.nbti.problem.application.dto.request.ProblemUpdateRequest;
 import com.dao.nbti.problem.application.dto.response.ProblemDetailsResponse;
 import com.dao.nbti.problem.application.dto.response.ProblemListResponse;
 import com.dao.nbti.problem.application.service.AdminProblemService;
@@ -40,6 +41,13 @@ public class AdminProblemController {
     public ResponseEntity<ApiResponse<ProblemDetailsResponse>> createProblem(@Valid @RequestBody ProblemCreateRequest problemCreateRequest) {
 
         return ResponseEntity.ok(ApiResponse.success(adminProblemService.createProblem(problemCreateRequest)));
+    }
+
+    @PutMapping("/{problemId}")
+    @Operation(summary = "문제 수정", description = "관리자가 서비스에 등록된 문제를 수정합니다.")
+    public ResponseEntity<ApiResponse<ProblemDetailsResponse>> updateProblem(@Valid @RequestBody ProblemUpdateRequest problemUpdateRequest, @PathVariable int problemId) {
+
+        return ResponseEntity.ok(ApiResponse.success(adminProblemService.updateProblem(problemUpdateRequest, problemId)));
     }
 
 }

--- a/NBTI/src/main/java/com/dao/nbti/problem/application/controller/AdminProblemController.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/application/controller/AdminProblemController.java
@@ -1,12 +1,14 @@
 package com.dao.nbti.problem.application.controller;
 
 import com.dao.nbti.common.dto.ApiResponse;
+import com.dao.nbti.common.exception.ErrorCode;
 import com.dao.nbti.problem.application.dto.request.ProblemCreateRequest;
 import com.dao.nbti.problem.application.dto.request.ProblemSearchRequest;
 import com.dao.nbti.problem.application.dto.request.ProblemUpdateRequest;
 import com.dao.nbti.problem.application.dto.response.ProblemDetailsResponse;
 import com.dao.nbti.problem.application.dto.response.ProblemListResponse;
 import com.dao.nbti.problem.application.service.AdminProblemService;
+import com.dao.nbti.problem.exception.ProblemException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -48,6 +50,14 @@ public class AdminProblemController {
     public ResponseEntity<ApiResponse<ProblemDetailsResponse>> updateProblem(@Valid @RequestBody ProblemUpdateRequest problemUpdateRequest, @PathVariable int problemId) {
 
         return ResponseEntity.ok(ApiResponse.success(adminProblemService.updateProblem(problemUpdateRequest, problemId)));
+    }
+
+    @ExceptionHandler(ProblemException.class)
+    public ResponseEntity<ApiResponse<Void>> handleProblemException(ProblemException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.failure(errorCode.getCode(), errorCode.getMessage()));
     }
 
 }

--- a/NBTI/src/main/java/com/dao/nbti/problem/application/dto/request/ProblemCommandRequest.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/application/dto/request/ProblemCommandRequest.java
@@ -1,0 +1,9 @@
+package com.dao.nbti.problem.application.dto.request;
+
+public interface ProblemCommandRequest {
+    int getCategoryId();
+    int getAnswerTypeId();
+    String getContentImageUrl();
+    String getCorrectAnswer();
+    int getLevel();
+}

--- a/NBTI/src/main/java/com/dao/nbti/problem/application/dto/request/ProblemUpdateRequest.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/application/dto/request/ProblemUpdateRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
-public class ProblemCreateRequest implements ProblemCommandRequest {
+public class ProblemUpdateRequest implements ProblemCommandRequest {
     private int categoryId;
     private int answerTypeId;
     @NotBlank

--- a/NBTI/src/main/java/com/dao/nbti/problem/application/dto/response/ProblemDTO.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/application/dto/response/ProblemDTO.java
@@ -1,5 +1,7 @@
 package com.dao.nbti.problem.application.dto.response;
 
+import com.dao.nbti.problem.domain.aggregate.Category;
+import com.dao.nbti.problem.domain.aggregate.Problem;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -26,5 +28,19 @@ public class ProblemDTO {
         this.contentImageUrl = contentImageUrl;
         this.correctAnswer = correctAnswer;
         this.level = level;
+    }
+
+    public static ProblemDTO from(Problem problem, Category childCategory, Category parentCategory, String answerTypeDescription) {
+        return ProblemDTO.builder()
+                .problemId(problem.getProblemId())
+                .categoryId(problem.getCategoryId())
+                .parentCategoryName(parentCategory.getName())
+                .childCategoryName(childCategory.getName())
+                .answerTypeId(problem.getAnswerTypeId())
+                .answerTypeDescription(answerTypeDescription)
+                .contentImageUrl(problem.getContentImageUrl())
+                .correctAnswer(problem.getCorrectAnswer())
+                .level(problem.getLevel())
+                .build();
     }
 }

--- a/NBTI/src/main/java/com/dao/nbti/problem/application/dto/response/ProblemDeleteResponse.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/application/dto/response/ProblemDeleteResponse.java
@@ -1,0 +1,10 @@
+package com.dao.nbti.problem.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProblemDeleteResponse {
+    private int problemId;
+}

--- a/NBTI/src/main/java/com/dao/nbti/problem/application/service/AdminProblemService.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/application/service/AdminProblemService.java
@@ -2,8 +2,10 @@ package com.dao.nbti.problem.application.service;
 
 import com.dao.nbti.common.dto.Pagination;
 import com.dao.nbti.common.exception.ErrorCode;
+import com.dao.nbti.problem.application.dto.request.ProblemCommandRequest;
 import com.dao.nbti.problem.application.dto.request.ProblemCreateRequest;
 import com.dao.nbti.problem.application.dto.request.ProblemSearchRequest;
+import com.dao.nbti.problem.application.dto.request.ProblemUpdateRequest;
 import com.dao.nbti.problem.application.dto.response.ProblemDTO;
 import com.dao.nbti.problem.application.dto.response.ProblemDetailsResponse;
 import com.dao.nbti.problem.application.dto.response.ProblemListResponse;
@@ -48,28 +50,16 @@ public class AdminProblemService {
     public ProblemDetailsResponse getProblemDetails(int problemId) {
         Problem problem = problemRepository.findById(problemId)
                 .orElseThrow(() -> new ProblemException(ErrorCode.PROBLEM_NOT_FOUND));
-        Category category = categoryRepository.findById(problem.getCategoryId())
+        Category childCategory = categoryRepository.findById(problem.getCategoryId())
                 .orElseThrow(() -> new ProblemException(ErrorCode.CATEGORY_NOT_FOUND));
-        Category parentCategory = categoryRepository.findById(category.getParentCategoryId())
+        Category parentCategory = categoryRepository.findById(childCategory.getParentCategoryId())
                 .orElseThrow(() -> new ProblemException(ErrorCode.CATEGORY_NOT_FOUND));
         AnswerType answerType = answerTypeRepository.findById(problem.getAnswerTypeId())
                 .orElseThrow(() -> new ProblemException(ErrorCode.ANSWER_TYPE_NOT_FOUND));
 
-        String childCategoryName = category.getName();
-        String parentCategoryName = parentCategory.getName();
         String answerTypeDescription = AnswerTypeEnum.of(answerType.getAnswerTypeId());
 
-        ProblemDTO problemDTO = ProblemDTO.builder()
-                .problemId(problem.getProblemId())
-                .categoryId(problem.getProblemId())
-                .parentCategoryName(parentCategoryName)
-                .childCategoryName(childCategoryName)
-                .answerTypeId(problem.getAnswerTypeId())
-                .answerTypeDescription(answerTypeDescription)
-                .contentImageUrl(problem.getContentImageUrl())
-                .correctAnswer(problem.getCorrectAnswer())
-                .level(problem.getLevel())
-                .build();
+        ProblemDTO problemDTO = ProblemDTO.from(problem, childCategory, parentCategory, answerTypeDescription);
 
         return ProblemDetailsResponse.builder()
                 .problem(problemDTO)
@@ -85,7 +75,7 @@ public class AdminProblemService {
         String correctAnswer = problemCreateRequest.getCorrectAnswer();
         int level = problemCreateRequest.getLevel();
 
-        validateProblemCreateRequest(problemCreateRequest);
+        validateProblemCommandRequest(problemCreateRequest);
 
         Problem problem = Problem.builder()
                 .categoryId(categoryId)
@@ -97,33 +87,40 @@ public class AdminProblemService {
                 .build();
 
         Problem saved = problemRepository.save(problem);
-        String answerTypeDescription = AnswerTypeEnum.of(problemCreateRequest.getAnswerTypeId());
 
         Category childCategory = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new ProblemException(ErrorCode.CATEGORY_NOT_FOUND));
         Category parentCategory = categoryRepository.findById(childCategory.getParentCategoryId())
                 .orElseThrow(() -> new ProblemException(ErrorCode.CATEGORY_NOT_FOUND));
+        String answerTypeDescription = AnswerTypeEnum.of(problemCreateRequest.getAnswerTypeId());
 
-        ProblemDTO problemDTO = ProblemDTO.builder()
-                .problemId(saved.getProblemId())
-                .categoryId(categoryId)
-                .parentCategoryName(parentCategory.getName())
-                .childCategoryName(childCategory.getName())
-                .answerTypeId(answerTypeId)
-                .answerTypeDescription(answerTypeDescription)
-                .contentImageUrl(contentImageUrl)
-                .correctAnswer(correctAnswer)
-                .level(level)
-                .build();
+        ProblemDTO problemDTO = ProblemDTO.from(saved, childCategory, parentCategory, answerTypeDescription);
 
         return ProblemDetailsResponse.builder()
                 .problem(problemDTO)
                 .build();
     }
 
-    private void validateProblemCreateRequest(ProblemCreateRequest problemCreateRequest) {
-        int categoryId = problemCreateRequest.getCategoryId();
-        int answerTypeId = problemCreateRequest.getAnswerTypeId();
+    @Transactional
+    public ProblemDetailsResponse updateProblem(ProblemUpdateRequest problemUpdateRequest, int problemId) {
+        Problem problem = problemRepository.findById(problemId)
+                .orElseThrow(() -> new ProblemException(ErrorCode.PROBLEM_NOT_FOUND));
+        validateProblemCommandRequest(problemUpdateRequest);
+        problem.updateFromRequest(problemUpdateRequest);
+
+        Category childCategory = categoryRepository.findById(problem.getCategoryId())
+                .orElseThrow(() -> new ProblemException(ErrorCode.CATEGORY_NOT_FOUND));
+        Category parentCategory = categoryRepository.findById(childCategory.getParentCategoryId())
+                .orElseThrow(() -> new ProblemException(ErrorCode.CATEGORY_NOT_FOUND));
+        String answerTypeDescription = AnswerTypeEnum.of(problem.getAnswerTypeId());
+
+        ProblemDTO problemDTO = ProblemDTO.from(problem, childCategory, parentCategory, answerTypeDescription);
+        return ProblemDetailsResponse.builder().problem(problemDTO).build();
+    }
+
+    private void validateProblemCommandRequest(ProblemCommandRequest problemCommandRequest) {
+        int categoryId = problemCommandRequest.getCategoryId();
+        int answerTypeId = problemCommandRequest.getAnswerTypeId();
         Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new ProblemException(ErrorCode.CATEGORY_NOT_FOUND));
 

--- a/NBTI/src/main/java/com/dao/nbti/problem/domain/aggregate/Problem.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/domain/aggregate/Problem.java
@@ -1,5 +1,6 @@
 package com.dao.nbti.problem.domain.aggregate;
 
+import com.dao.nbti.problem.application.dto.request.ProblemCommandRequest;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -36,5 +37,13 @@ public class Problem {
         this.correctAnswer = correctAnswer;
         this.isDeleted = isDeleted;
         this.level = level;
+    }
+
+    public void updateFromRequest(ProblemCommandRequest request) {
+        this.categoryId = request.getCategoryId();
+        this.answerTypeId = request.getAnswerTypeId();
+        this.contentImageUrl = request.getContentImageUrl();
+        this.correctAnswer = request.getCorrectAnswer();
+        this.level = request.getLevel();
     }
 }

--- a/NBTI/src/main/java/com/dao/nbti/problem/domain/repository/ProblemRepository.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/domain/repository/ProblemRepository.java
@@ -1,11 +1,15 @@
 package com.dao.nbti.problem.domain.repository;
 
+import com.dao.nbti.problem.domain.aggregate.IsDeleted;
 import com.dao.nbti.problem.domain.aggregate.Problem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProblemRepository extends JpaRepository<Problem, Integer> {
 
@@ -34,5 +38,16 @@ public interface ProblemRepository extends JpaRepository<Problem, Integer> {
     """, nativeQuery = true)
     List<Problem> findRandomProblemsByParentCategoryAndLevel(@Param("parentCategoryId") Integer parentCategoryId,
                                                              @Param("level") int level);
+
+    Optional<Problem> findByProblemIdAndIsDeleted(int problemId, IsDeleted isDeleted);
+
+    @Modifying
+    @Transactional
+    @Query("""
+    UPDATE Problem p SET p.isDeleted = :isDeleted WHERE p.problemId = :problemId
+""")
+    void deleteByProblemId(int problemId, IsDeleted isDeleted);
+
+    boolean existsByProblemIdAndIsDeleted(int problemId, IsDeleted isDeleted);
 }
 


### PR DESCRIPTION
closes #030 and #031

---

📌 개요
- 문제 수정 기능 구현
- 문제 삭제 기능 구현

🔨 주요 변경 사항
- 문제 수정 기능 구현
- 문제 삭제 기능 구현
- soft delete이 고려되지 않은 조회 메서드 수정
- 공통 로직 재사용을 위한 리팩토링
  - `ProblemCommandRequest` 인터페이스를 정의하고 구현하도록 수정
  - DTO 및 Entity에 변환 로직 작성 (서비스의 책임을 낮춤)
✅ 리뷰 요청 사항

⭐ 관련 이슈
#030, #031
