### PR TITLE
[feat #033] 관리자 이의 제기 목록 조회 기능 구현

### DIFF
--- a/NBTI/src/main/java/com/dao/nbti/objection/application/controller/AdminObjectionController.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/controller/AdminObjectionController.java
@@ -1,0 +1,35 @@
+package com.dao.nbti.objection.application.controller;
+
+import com.dao.nbti.common.dto.ApiResponse;
+import com.dao.nbti.objection.application.dto.request.AdminObjectionSearchRequest;
+import com.dao.nbti.objection.application.dto.response.AdminObjectionListResponse;
+import com.dao.nbti.objection.application.dto.response.ObjectionSummaryResponse;
+import com.dao.nbti.objection.application.service.AdminObjectionService;
+import com.dao.nbti.objection.domain.aggregate.Status;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/objections")
+@RequiredArgsConstructor
+@Tag(name = "이의 제기 관리", description = "관리자 이의 제기 관리 API")
+public class AdminObjectionController {
+
+    private final AdminObjectionService adminObjectionService;
+
+    @Operation(summary = "이의 제기 목록 조회", description = "관리자가 이의 제기 목록을 조회합니다. 회원 아이디, 문제 ID, 상태로 필터링할 수 있습니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<AdminObjectionListResponse>> getObjections(
+            @ModelAttribute AdminObjectionSearchRequest adminObjectionSearchRequest
+            ) {
+        AdminObjectionListResponse objections = adminObjectionService.getObjections(adminObjectionSearchRequest);
+        return ResponseEntity.ok(ApiResponse.success(objections));
+    }
+}

--- a/NBTI/src/main/java/com/dao/nbti/objection/application/dto/request/AdminObjectionSearchRequest.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/dto/request/AdminObjectionSearchRequest.java
@@ -1,0 +1,34 @@
+package com.dao.nbti.objection.application.dto.request;
+
+import com.dao.nbti.objection.domain.aggregate.Status;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class AdminObjectionSearchRequest {
+    private Integer page;
+    private Integer size;
+
+    private String accountId;
+    private Integer problemId;
+    private Status status;
+
+    public int getOffset() {
+        return (getPage() - 1) * getSize();
+    }
+
+    public int getLimit() {
+        return getSize();
+    }
+
+    public int getPage() {
+        return page != null ? page : 1;
+    }
+
+    public int getSize() {
+        return size != null ? size : 10;
+    }
+}

--- a/NBTI/src/main/java/com/dao/nbti/objection/application/dto/response/AdminObjectionDTO.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/dto/response/AdminObjectionDTO.java
@@ -1,0 +1,27 @@
+package com.dao.nbti.objection.application.dto.response;
+
+import com.dao.nbti.objection.domain.aggregate.Status;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdminObjectionDTO {
+    private int userId;
+    private String accountId;
+    private int objectionId;
+    private int problemId;
+    private Status status;           // 상태: PENDING / ACCEPTED / REJECTED
+    private LocalDateTime createdAt; // 제출 일시
+
+    public AdminObjectionDTO(int userId, String accountId, int objectionId, int problemId, Status status, LocalDateTime createdAt) {
+        this.userId = userId;
+        this.accountId = accountId;
+        this.objectionId = objectionId;
+        this.problemId = problemId;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+}

--- a/NBTI/src/main/java/com/dao/nbti/objection/application/dto/response/AdminObjectionListResponse.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/dto/response/AdminObjectionListResponse.java
@@ -1,0 +1,14 @@
+package com.dao.nbti.objection.application.dto.response;
+
+import com.dao.nbti.common.dto.Pagination;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AdminObjectionListResponse {
+    private List<AdminObjectionDTO> objections;
+    private Pagination pagination;
+}

--- a/NBTI/src/main/java/com/dao/nbti/objection/application/service/AdminObjectionService.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/service/AdminObjectionService.java
@@ -1,0 +1,34 @@
+package com.dao.nbti.objection.application.service;
+
+import com.dao.nbti.common.dto.Pagination;
+import com.dao.nbti.objection.application.dto.request.AdminObjectionSearchRequest;
+import com.dao.nbti.objection.application.dto.response.AdminObjectionDTO;
+import com.dao.nbti.objection.application.dto.response.AdminObjectionListResponse;
+import com.dao.nbti.objection.domain.repository.ObjectionRepositoryCustom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminObjectionService {
+    private final ObjectionRepositoryCustom objectionRepositoryCustom;
+
+    @Transactional(readOnly = true)
+    public AdminObjectionListResponse getObjections(AdminObjectionSearchRequest adminObjectionSearchRequest) {
+        List<AdminObjectionDTO> objections = objectionRepositoryCustom.getObjections(adminObjectionSearchRequest);
+
+        long totalItems = objectionRepositoryCustom.countObjectionsBy(adminObjectionSearchRequest);
+
+        return AdminObjectionListResponse.builder()
+                .objections(objections)
+                .pagination(Pagination.builder()
+                                .currentPage(adminObjectionSearchRequest.getPage())
+                                .totalItems(totalItems)
+                                .totalPage((int) Math.ceil((double) totalItems / adminObjectionSearchRequest.getSize()))
+                                .build())
+                .build();
+    }
+}

--- a/NBTI/src/main/java/com/dao/nbti/objection/domain/repository/ObjectionRepositoryCustom.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/domain/repository/ObjectionRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.dao.nbti.objection.domain.repository;
+
+import com.dao.nbti.objection.application.dto.request.AdminObjectionSearchRequest;
+import com.dao.nbti.objection.application.dto.response.AdminObjectionDTO;
+
+import java.util.List;
+
+public interface ObjectionRepositoryCustom {
+    List<AdminObjectionDTO> getObjections(AdminObjectionSearchRequest request);
+
+    long countObjectionsBy(AdminObjectionSearchRequest request);
+}

--- a/NBTI/src/main/java/com/dao/nbti/objection/domain/repository/ObjectionRepositoryImpl.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/domain/repository/ObjectionRepositoryImpl.java
@@ -1,0 +1,86 @@
+package com.dao.nbti.objection.domain.repository;
+
+import com.dao.nbti.objection.application.dto.request.AdminObjectionSearchRequest;
+import com.dao.nbti.objection.application.dto.response.AdminObjectionDTO;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class ObjectionRepositoryImpl implements ObjectionRepositoryCustom {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public List<AdminObjectionDTO> getObjections(AdminObjectionSearchRequest request) {
+        String initQuery = """
+        SELECT new com.dao.nbti.objection.application.dto.response.AdminObjectionDTO(
+            o.userId, u.accountId, o.objectionId, o.problemId, o.status, o.createdAt
+        )
+        FROM Objection o
+        JOIN User u ON u.userId = o.userId
+        WHERE 1 = 1
+        """;
+        String jpql = getDynamicQuery(initQuery, request);
+
+        TypedQuery<AdminObjectionDTO> query = em.createQuery(jpql, AdminObjectionDTO.class);
+
+        if (request.getAccountId() != null) {
+            query.setParameter("accountId", request.getAccountId());
+        }
+        if (request.getProblemId() != null) {
+            query.setParameter("problemId", request.getProblemId());
+        }
+        if (request.getStatus() != null) {
+            query.setParameter("status", request.getStatus());
+        }
+
+        return query
+                .setFirstResult(request.getOffset())
+                .setMaxResults(request.getLimit())
+                .getResultList();
+    }
+
+    @Override
+    public long countObjectionsBy(AdminObjectionSearchRequest request) {
+        String initQuery = """
+        SELECT COUNT(o)
+        FROM Objection o
+        JOIN User u ON u.userId = o.userId
+        WHERE 1 = 1
+        """;
+        String jpql = getDynamicQuery(initQuery, request);
+
+        TypedQuery<Long> query = em.createQuery(jpql, Long.class);
+        if (request.getAccountId() != null) {
+            query.setParameter("accountId", request.getAccountId());
+        }
+        if (request.getProblemId() != null) {
+            query.setParameter("problemId", request.getProblemId());
+        }
+        if (request.getStatus() != null) {
+            query.setParameter("status", request.getStatus());
+        }
+
+        return query.getSingleResult();
+    }
+
+    private static String getDynamicQuery(String str, AdminObjectionSearchRequest request) {
+        StringBuilder jpql = new StringBuilder(str);
+
+        if (request.getAccountId() != null) {
+            jpql.append("\nAND u.accountId = :accountId");
+        }
+
+        if (request.getProblemId() != null) {
+            jpql.append("\nAND o.problemId = :problemId");
+        }
+        if (request.getStatus() != null) {
+            jpql.append("\nAND o.status = :status");
+        }
+        return jpql.toString();
+    }
+}


### PR DESCRIPTION
closes #033
---

📌 개요
- 관리자 이의 제기 목록 조회 기능 구현
🔨 주요 변경 사항
- 컨트롤러, repository, dto, 서비스 작성
- postman 테스트 완료
✅ 리뷰 요청 사항

⭐ 관련 이슈
#33 
