### PR TITLE
feat: 학습 결과 조회 api 구현

### DIFF
--- a/NBTI/src/main/java/com/dao/nbti/common/exception/ErrorCode.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/exception/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
     PROBLEM_NOT_FOUND("20003", "해당하는 문제가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     PARENT_CATEGORY_NOT_FOUND("20004", "상위 분야를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     PROBLEM_DELETED("20005", "삭제된 문제입니다.", HttpStatus.GONE),
+    STUDY_RESULT_NOT_FOUND("20006", "학습 결과가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    STUDY_NOT_FOUND("20007", "학습이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    STUDY_ACCESS_DENIED("20008", "학습을 조회할 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
     // 검사 결과 오류 (30000 ~ 39999)
     TEST_RESULT_NOT_FOUND("30001", "검사 결과를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/NBTI/src/main/java/com/dao/nbti/study/application/controller/StudyController.java
+++ b/NBTI/src/main/java/com/dao/nbti/study/application/controller/StudyController.java
@@ -4,10 +4,10 @@ import com.dao.nbti.common.dto.ApiResponse;
 import com.dao.nbti.common.exception.ErrorCode;
 import com.dao.nbti.study.application.dto.request.SubmitStudyRequestDto;
 import com.dao.nbti.study.application.dto.response.ProblemResponseDto;
+import com.dao.nbti.study.application.dto.response.StudyResultDetailResponseDto;
 import com.dao.nbti.study.application.dto.response.SubmitStudyResponseDto;
 import com.dao.nbti.study.application.service.StudyService;
-import com.dao.nbti.study.exception.NoSuchAnswerTypeException;
-import com.dao.nbti.study.exception.NoSuchCategoryException;
+import com.dao.nbti.study.exception.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -49,6 +49,17 @@ public class StudyController {
     }
 
 
+    @GetMapping("/result/{studyId}")
+    @Operation(summary = "학습 결과 조회", description = "해당 학습 ID의 문제 채점 결과를 반환합니다.")
+    public ResponseEntity<ApiResponse<StudyResultDetailResponseDto>> getStudyResult(
+            @PathVariable int studyId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        StudyResultDetailResponseDto response = studyService.getStudyResultDetail(studyId, userDetails);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+
     @ExceptionHandler(NoSuchCategoryException.class)
     public ResponseEntity<ApiResponse<Void>> handleNoSuchCategoryException(NoSuchCategoryException e) {
         ErrorCode errorCode = e.getErrorCode();
@@ -59,6 +70,38 @@ public class StudyController {
 
     @ExceptionHandler(NoSuchAnswerTypeException.class)
     public ResponseEntity<ApiResponse<Void>> handleNoSuchAnswerTypeException(NoSuchAnswerTypeException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.failure(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(ProblemNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleProblemNotFoundException(ProblemNotFoundException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.failure(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidAccessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleInvalidAccessException(InvalidAccessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.failure(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(StudyNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleStudyNotFoundException(StudyNotFoundException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.failure(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(StudyResultNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleStudyResultNotFoundException(StudyResultNotFoundException e) {
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getHttpStatus())

--- a/NBTI/src/main/java/com/dao/nbti/study/application/dto/response/StudyResultDetailResponseDto.java
+++ b/NBTI/src/main/java/com/dao/nbti/study/application/dto/response/StudyResultDetailResponseDto.java
@@ -10,7 +10,6 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 public class StudyResultDetailResponseDto {
-
     private int studyId;
     private int totalCount;
     private int correctCount;
@@ -22,6 +21,7 @@ public class StudyResultDetailResponseDto {
     public static class StudyResultItem {
         private int studyResultId;
         private int problemId;
+        private String contentImageUrl;
         private boolean isCorrect;
         private int level;
         private String submittedAnswer;

--- a/NBTI/src/main/java/com/dao/nbti/study/application/dto/response/StudyResultDetailResponseDto.java
+++ b/NBTI/src/main/java/com/dao/nbti/study/application/dto/response/StudyResultDetailResponseDto.java
@@ -1,0 +1,30 @@
+package com.dao.nbti.study.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class StudyResultDetailResponseDto {
+
+    private int studyId;
+    private int totalCount;
+    private int correctCount;
+    private List<StudyResultItem> results;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class StudyResultItem {
+        private int studyResultId;
+        private int problemId;
+        private boolean isCorrect;
+        private int level;
+        private String submittedAnswer;
+        private String parentCategoryName;
+    }
+}

--- a/NBTI/src/main/java/com/dao/nbti/study/application/service/StudyService.java
+++ b/NBTI/src/main/java/com/dao/nbti/study/application/service/StudyService.java
@@ -9,20 +9,21 @@ import com.dao.nbti.problem.domain.repository.CategoryRepository;
 import com.dao.nbti.problem.domain.repository.ProblemRepository;
 import com.dao.nbti.study.application.dto.request.SubmitStudyRequestDto;
 import com.dao.nbti.study.application.dto.response.ProblemResponseDto;
+import com.dao.nbti.study.application.dto.response.StudyResultDetailResponseDto;
 import com.dao.nbti.study.application.dto.response.SubmitStudyResponseDto;
 import com.dao.nbti.study.domain.aggregate.IsCorrect;
 import com.dao.nbti.study.domain.aggregate.Study;
 import com.dao.nbti.study.domain.aggregate.StudyResult;
 import com.dao.nbti.study.domain.repository.StudyRepository;
 import com.dao.nbti.study.domain.repository.StudyResultRepository;
-import com.dao.nbti.study.exception.NoSuchAnswerTypeException;
-import com.dao.nbti.study.exception.NoSuchCategoryException;
-import com.dao.nbti.study.exception.ProblemNotFoundException;
+import com.dao.nbti.study.exception.*;
+import com.dao.nbti.user.domain.aggregate.Authority;
 import com.dao.nbti.user.domain.aggregate.PointHistory;
 import com.dao.nbti.user.domain.aggregate.PointType;
 import com.dao.nbti.user.domain.repository.PointHistoryRepository;
 import com.dao.nbti.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -109,4 +110,60 @@ public class StudyService {
                 .studyId(study.getStudyId())
                 .build();
     }
+
+    public StudyResultDetailResponseDto getStudyResultDetail(int studyId, UserDetails userDetails) {
+        Study study = studyRepository.findById(studyId)
+                .orElseThrow(() -> new StudyNotFoundException(ErrorCode.STUDY_NOT_FOUND));
+
+        // 학습의 주인이 요청한 사람인지 확인
+        boolean isOwner = study.getUserId().equals(Integer.parseInt(userDetails.getUsername()));
+
+        // 혹은 요청한 사람이 ADMIN인지 확인
+        String authorityName = userDetails.getAuthorities().iterator().next().getAuthority();
+        Authority role = Authority.valueOf(authorityName); // 문자열 → enum 변환
+
+        boolean isAdmin = role == Authority.ADMIN;
+
+        // ADMIN도 아니고, 학습한 사람도 아니면 에러처리
+        if (!isOwner && !isAdmin) {
+            throw new InvalidAccessException(ErrorCode.STUDY_ACCESS_DENIED);
+        }
+
+        List<StudyResult> results = studyResultRepository.findByStudyId(studyId);
+        if (results.isEmpty()) {
+            throw new StudyResultNotFoundException(ErrorCode.STUDY_RESULT_NOT_FOUND);
+        }
+
+        List<StudyResultDetailResponseDto.StudyResultItem> resultItems = results.stream().map(result -> {
+            Problem problem = problemRepository.findById(result.getProblemId())
+                    .orElseThrow(() -> new ProblemNotFoundException(ErrorCode.PROBLEM_NOT_FOUND));
+
+            Category category = categoryRepository.findById(problem.getCategoryId())
+                    .orElseThrow(() -> new NoSuchCategoryException(ErrorCode.CATEGORY_NOT_FOUND));
+
+            Category parentCategory = categoryRepository.findById(category.getParentCategoryId())
+                    .orElseThrow(() -> new NoSuchCategoryException(ErrorCode.CATEGORY_NOT_FOUND));
+
+            return StudyResultDetailResponseDto.StudyResultItem.builder()
+                    .studyResultId(result.getStudyResultId())
+                    .problemId(problem.getProblemId())
+                    .isCorrect(result.getIsCorrect() == IsCorrect.Y)
+                    .level(problem.getLevel())
+                    .submittedAnswer(result.getAnswer())
+                    .parentCategoryName(parentCategory.getName())
+                    .build();
+        }).toList();
+
+        int correctCount = (int) results.stream()
+                .filter(r -> r.getIsCorrect() == IsCorrect.Y)
+                .count();
+
+        return StudyResultDetailResponseDto.builder()
+                .studyId(studyId)
+                .totalCount(resultItems.size())
+                .correctCount(correctCount)
+                .results(resultItems)
+                .build();
+    }
+
 }

--- a/NBTI/src/main/java/com/dao/nbti/study/application/service/StudyService.java
+++ b/NBTI/src/main/java/com/dao/nbti/study/application/service/StudyService.java
@@ -151,6 +151,7 @@ public class StudyService {
                     .level(problem.getLevel())
                     .submittedAnswer(result.getAnswer())
                     .parentCategoryName(parentCategory.getName())
+                    .contentImageUrl(problem.getContentImageUrl())
                     .build();
         }).toList();
 

--- a/NBTI/src/main/java/com/dao/nbti/study/exception/InvalidAccessException.java
+++ b/NBTI/src/main/java/com/dao/nbti/study/exception/InvalidAccessException.java
@@ -1,0 +1,14 @@
+package com.dao.nbti.study.exception;
+
+import com.dao.nbti.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class InvalidAccessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public InvalidAccessException(final ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/NBTI/src/main/java/com/dao/nbti/study/exception/StudyNotFoundException.java
+++ b/NBTI/src/main/java/com/dao/nbti/study/exception/StudyNotFoundException.java
@@ -1,0 +1,14 @@
+package com.dao.nbti.study.exception;
+
+import com.dao.nbti.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class StudyNotFoundException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public StudyNotFoundException(final ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/NBTI/src/main/java/com/dao/nbti/study/exception/StudyResultNotFoundException.java
+++ b/NBTI/src/main/java/com/dao/nbti/study/exception/StudyResultNotFoundException.java
@@ -1,0 +1,14 @@
+package com.dao.nbti.study.exception;
+
+import com.dao.nbti.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class StudyResultNotFoundException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public StudyResultNotFoundException(final ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}


### PR DESCRIPTION
closes #24 

---

📌 개요
학습 결과 조회 api 구현

🔨 주요 변경 사항
- 학습 ID를 통해 학습된 결과를 제공받는 api 구현(총 문제수, 맞은 문제수, 제출한 답안, 문제 정보 제공)
- 학습한 사용자가 요청하거나, 관리자가 요청한 경우에만 해당 학습에 들어있는 학습 결과 내용을 조회할 수 있도록 에러처리

⭐ 관련 이슈
#24 
