### PR TITLE
feat: 관리자 이의 제기 상세 조회 기능 구현

### DIFF
--- a/NBTI/src/main/java/com/dao/nbti/objection/application/controller/AdminObjectionController.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/controller/AdminObjectionController.java
@@ -2,19 +2,14 @@ package com.dao.nbti.objection.application.controller;
 
 import com.dao.nbti.common.dto.ApiResponse;
 import com.dao.nbti.objection.application.dto.request.AdminObjectionSearchRequest;
+import com.dao.nbti.objection.application.dto.response.AdminObjectionDetailResponse;
 import com.dao.nbti.objection.application.dto.response.AdminObjectionListResponse;
-import com.dao.nbti.objection.application.dto.response.ObjectionSummaryResponse;
 import com.dao.nbti.objection.application.service.AdminObjectionService;
-import com.dao.nbti.objection.domain.aggregate.Status;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/admin/objections")
@@ -31,5 +26,14 @@ public class AdminObjectionController {
             ) {
         AdminObjectionListResponse objections = adminObjectionService.getObjections(adminObjectionSearchRequest);
         return ResponseEntity.ok(ApiResponse.success(objections));
+    }
+
+    @Operation(summary = "이의 제기 상세 조회", description = "관리자가 이의 제기 상세 내용을 조회합니다.")
+    @GetMapping("/{objectionId}")
+    public ResponseEntity<ApiResponse<AdminObjectionDetailResponse>> getObjectionDetails(
+            @PathVariable int objectionId
+    ) {
+        AdminObjectionDetailResponse objection = adminObjectionService.getObjectionDetails(objectionId);
+        return ResponseEntity.ok(ApiResponse.success(objection));
     }
 }

--- a/NBTI/src/main/java/com/dao/nbti/objection/application/dto/response/AdminObjectionDTO.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/dto/response/AdminObjectionDTO.java
@@ -9,14 +9,14 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class AdminObjectionDTO {
-    private int userId;
+    private Integer userId;
     private String accountId;
     private int objectionId;
     private int problemId;
     private Status status;           // 상태: PENDING / ACCEPTED / REJECTED
     private LocalDateTime createdAt; // 제출 일시
 
-    public AdminObjectionDTO(int userId, String accountId, int objectionId, int problemId, Status status, LocalDateTime createdAt) {
+    public AdminObjectionDTO(Integer userId, String accountId, int objectionId, int problemId, Status status, LocalDateTime createdAt) {
         this.userId = userId;
         this.accountId = accountId;
         this.objectionId = objectionId;

--- a/NBTI/src/main/java/com/dao/nbti/objection/application/dto/response/AdminObjectionDetailResponse.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/dto/response/AdminObjectionDetailResponse.java
@@ -1,0 +1,10 @@
+package com.dao.nbti.objection.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminObjectionDetailResponse {
+    private AdminObjectionDetailsDTO objectionDetails;
+}

--- a/NBTI/src/main/java/com/dao/nbti/objection/application/dto/response/AdminObjectionDetailsDTO.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/dto/response/AdminObjectionDetailsDTO.java
@@ -1,0 +1,50 @@
+package com.dao.nbti.objection.application.dto.response;
+
+import com.dao.nbti.objection.domain.aggregate.Objection;
+import com.dao.nbti.objection.domain.aggregate.Status;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class AdminObjectionDetailsDTO {
+    private int objectionId;
+    private Integer userId;
+    private String accountId;
+    private int problemId;
+    private Status status;
+
+    private String reason;           // 제출한 사유
+    private String information;      // 처리 정보
+
+    private LocalDateTime createdAt;     // 제출 일시
+    private LocalDateTime processedAt;   // 처리 일시
+
+    @Builder
+    public AdminObjectionDetailsDTO(Integer userId, String accountId, int objectionId, int problemId, Status status, String reason, String information, LocalDateTime createdAt, LocalDateTime processedAt) {
+        this.userId = userId;
+        this.accountId = accountId;
+        this.objectionId = objectionId;
+        this.problemId = problemId;
+        this.status = status;
+        this.reason = reason;
+        this.information = information;
+        this.createdAt = createdAt;
+        this.processedAt = processedAt;
+    }
+
+    public static AdminObjectionDetailsDTO from(Objection objection, String accountId) {
+        return AdminObjectionDetailsDTO.builder()
+                .objectionId(objection.getObjectionId())
+                .userId(objection.getUserId())
+                .accountId(accountId)
+                .problemId(objection.getProblemId())
+                .reason(objection.getReason())
+                .information(objection.getInformation())
+                .status(objection.getStatus())
+                .createdAt(objection.getCreatedAt())
+                .processedAt(objection.getProcessedAt())
+                .build();
+    }
+}

--- a/NBTI/src/main/java/com/dao/nbti/objection/application/service/AdminObjectionService.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/service/AdminObjectionService.java
@@ -11,6 +11,7 @@ import com.dao.nbti.objection.domain.aggregate.Objection;
 import com.dao.nbti.objection.domain.repository.ObjectionRepository;
 import com.dao.nbti.objection.domain.repository.ObjectionRepositoryCustom;
 import com.dao.nbti.objection.exception.ObjectionException;
+import com.dao.nbti.user.domain.aggregate.IsDeleted;
 import com.dao.nbti.user.domain.aggregate.User;
 import com.dao.nbti.user.domain.repository.UserRepository;
 import com.dao.nbti.user.exception.UserException;
@@ -56,6 +57,9 @@ public class AdminObjectionService {
                     .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
             objectionDetails = AdminObjectionDetailsDTO.from(objection, user.getAccountId());
+            if (user.getIsDeleted() == IsDeleted.Y) {
+                objectionDetails = AdminObjectionDetailsDTO.from(objection, "삭제된 유저");
+            }
         }
         else {
             objectionDetails = AdminObjectionDetailsDTO.from(objection, "삭제된 유저");

--- a/NBTI/src/main/java/com/dao/nbti/objection/application/service/AdminObjectionService.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/service/AdminObjectionService.java
@@ -1,10 +1,19 @@
 package com.dao.nbti.objection.application.service;
 
 import com.dao.nbti.common.dto.Pagination;
+import com.dao.nbti.common.exception.ErrorCode;
 import com.dao.nbti.objection.application.dto.request.AdminObjectionSearchRequest;
 import com.dao.nbti.objection.application.dto.response.AdminObjectionDTO;
+import com.dao.nbti.objection.application.dto.response.AdminObjectionDetailResponse;
+import com.dao.nbti.objection.application.dto.response.AdminObjectionDetailsDTO;
 import com.dao.nbti.objection.application.dto.response.AdminObjectionListResponse;
+import com.dao.nbti.objection.domain.aggregate.Objection;
+import com.dao.nbti.objection.domain.repository.ObjectionRepository;
 import com.dao.nbti.objection.domain.repository.ObjectionRepositoryCustom;
+import com.dao.nbti.objection.exception.ObjectionException;
+import com.dao.nbti.user.domain.aggregate.User;
+import com.dao.nbti.user.domain.repository.UserRepository;
+import com.dao.nbti.user.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +24,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AdminObjectionService {
     private final ObjectionRepositoryCustom objectionRepositoryCustom;
+    private final ObjectionRepository objectionRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public AdminObjectionListResponse getObjections(AdminObjectionSearchRequest adminObjectionSearchRequest) {
@@ -29,6 +40,29 @@ public class AdminObjectionService {
                                 .totalItems(totalItems)
                                 .totalPage((int) Math.ceil((double) totalItems / adminObjectionSearchRequest.getSize()))
                                 .build())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public AdminObjectionDetailResponse getObjectionDetails(int objectionId) {
+        Objection objection = objectionRepository.findById(objectionId)
+                .orElseThrow(() -> new ObjectionException(ErrorCode.OBJECTION_NOT_FOUND));
+
+        Integer userId = objection.getUserId();
+        AdminObjectionDetailsDTO objectionDetails;
+
+        if (userId != null) {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+            objectionDetails = AdminObjectionDetailsDTO.from(objection, user.getAccountId());
+        }
+        else {
+            objectionDetails = AdminObjectionDetailsDTO.from(objection, "삭제된 유저");
+        }
+
+        return AdminObjectionDetailResponse.builder()
+                .objectionDetails(objectionDetails)
                 .build();
     }
 }


### PR DESCRIPTION
closes #34 

---

📌 개요
- 관리자 이의 제기 상세 조회 기능 구현
🔨 주요 변경 사항
- 컨트롤러, dto, 서비스 작성
- postman 테스트 완료
✅ 리뷰 요청 사항
- 삭제(hard delete/soft delete)된 유저의 이의 제기에 대한 응답이 적절한지
  - hard delete 된 유저일 때
![image](https://github.com/user-attachments/assets/8b189b45-55dd-457a-84b3-e093b5d984da)
  - soft delete 된 유저일 때~~는 활성화된 유저와 동일~~ "삭제된 유저"로 표시
![image](https://github.com/user-attachments/assets/5fb930ca-2854-4105-a8c2-bd5b8485e9c9)

⭐ 관련 이슈
#34 
