### PR TITLE
feat: 비밀번호 찾기 및 재설정 기능 구현

### DIFF
--- a/NBTI/src/main/java/com/dao/nbti/common/auth/application/controller/AuthController.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/auth/application/controller/AuthController.java
@@ -4,8 +4,8 @@ import com.dao.nbti.common.auth.application.dto.*;
 import com.dao.nbti.common.auth.application.service.AuthService;
 import com.dao.nbti.common.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.springframework.http.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -70,7 +70,7 @@ public class AuthController {
 
     @Operation(summary = "비밀번호 재설정", description = "사용자의 이름과 아이디 정보가 일치할 시 비밀번호를 재설정한다.")
     @GetMapping("/reset-password")
-    public ResponseEntity<ApiResponse<Void>> resetPassword(@RequestBody PasswordResetRequest request, @AuthenticationPrincipal UserDetails userDetails){
+    public ResponseEntity<ApiResponse<Void>> resetPassword(@RequestBody @Valid PasswordResetRequest request, @AuthenticationPrincipal UserDetails userDetails){
         authService.resetPassword(request, userDetails.getUsername());
 
         return ResponseEntity.ok().body(ApiResponse.success(null));

--- a/NBTI/src/main/java/com/dao/nbti/common/auth/application/controller/AuthController.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/auth/application/controller/AuthController.java
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
 import org.springframework.http.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Duration;
@@ -62,7 +64,16 @@ public class AuthController {
     public ResponseEntity<ApiResponse<TokenResponse>> requestPasswordReset(@RequestBody PasswordFindRequest request){
         TokenResponse response = authService.findPassword(request);
 
-        return ResponseEntity.ok().body(ApiResponse.success(response));
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "비밀번호 재설정", description = "사용자의 이름과 아이디 정보가 일치할 시 비밀번호를 재설정한다.")
+    @GetMapping("/reset-password")
+    public ResponseEntity<ApiResponse<Void>> resetPassword(@RequestBody PasswordResetRequest request, @AuthenticationPrincipal UserDetails userDetails){
+        authService.resetPassword(request, userDetails.getUsername());
+
+        return ResponseEntity.ok().body(ApiResponse.success(null));
     }
 
 

--- a/NBTI/src/main/java/com/dao/nbti/common/auth/application/controller/AuthController.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/auth/application/controller/AuthController.java
@@ -1,16 +1,12 @@
 package com.dao.nbti.common.auth.application.controller;
 
-import com.dao.nbti.common.auth.application.dto.LoginRequest;
-import com.dao.nbti.common.auth.application.dto.LoginResponse;
-import com.dao.nbti.common.auth.application.dto.TokenResponse;
+import com.dao.nbti.common.auth.application.dto.*;
 import com.dao.nbti.common.auth.application.service.AuthService;
 import com.dao.nbti.common.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
-import org.springframework.http.ResponseEntity;
+import org.apache.coyote.Response;
+import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Duration;
@@ -60,6 +56,15 @@ public class AuthController {
                 .header(HttpHeaders.SET_COOKIE, deleteCookie.toString())
                 .body(ApiResponse.success(null));
     }
+
+    @Operation(summary = "비밀번호 찾기", description = "사용자는 아이디와 이름을 입력하여 비밀번호 변경을 요청한다.")
+    @GetMapping("/find-password")
+    public ResponseEntity<ApiResponse<TokenResponse>> requestPasswordReset(@RequestBody PasswordFindRequest request){
+        TokenResponse response = authService.findPassword(request);
+
+        return ResponseEntity.ok().body(ApiResponse.success(response));
+    }
+
 
     private ResponseCookie createRefreshTokenCookie(String refreshToken) {
         return ResponseCookie.from("refreshToken", refreshToken)

--- a/NBTI/src/main/java/com/dao/nbti/common/auth/application/dto/PasswordFindRequest.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/auth/application/dto/PasswordFindRequest.java
@@ -1,0 +1,15 @@
+package com.dao.nbti.common.auth.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PasswordFindRequest {
+    @NotBlank
+    private final String accountId;
+
+    @NotBlank
+    private final String name;
+}

--- a/NBTI/src/main/java/com/dao/nbti/common/auth/application/dto/PasswordResetRequest.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/auth/application/dto/PasswordResetRequest.java
@@ -1,0 +1,13 @@
+package com.dao.nbti.common.auth.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PasswordResetRequest {
+    @NotBlank
+    private String password;
+    private String verifiedPassword;
+}

--- a/NBTI/src/main/java/com/dao/nbti/common/auth/application/service/AuthService.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/auth/application/service/AuthService.java
@@ -126,7 +126,7 @@ public class AuthService {
         tempRedisTemplate.opsForValue().set(
                 accountId,
                 tempToken,
-                Duration.ofDays(7)
+                60*5L
         );
 
         return TokenResponse.builder()

--- a/NBTI/src/main/java/com/dao/nbti/common/auth/application/service/AuthService.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/auth/application/service/AuthService.java
@@ -118,7 +118,7 @@ public class AuthService {
                 () -> new UserException(ErrorCode.USER_NOT_FOUND)
         );
 
-        String token = jwtTokenProvider.createToken(accountId,user.getAuthority().name());
+        String token = jwtTokenProvider.createToken("temp "+accountId,user.getAuthority().name());
         TempToken tempToken = TempToken.builder()
                 .token(token)
                 .build();

--- a/NBTI/src/main/java/com/dao/nbti/common/auth/application/service/AuthService.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/auth/application/service/AuthService.java
@@ -11,8 +11,6 @@ import com.dao.nbti.user.domain.repository.UserRepository;
 import com.dao.nbti.user.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/NBTI/src/main/java/com/dao/nbti/common/auth/application/service/AuthService.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/auth/application/service/AuthService.java
@@ -1,10 +1,7 @@
 package com.dao.nbti.common.auth.application.service;
 
 
-import com.dao.nbti.common.auth.application.dto.LoginRequest;
-import com.dao.nbti.common.auth.application.dto.LoginResponse;
-import com.dao.nbti.common.auth.application.dto.PasswordFindRequest;
-import com.dao.nbti.common.auth.application.dto.TokenResponse;
+import com.dao.nbti.common.auth.application.dto.*;
 import com.dao.nbti.common.auth.domain.aggregate.RefreshToken;
 import com.dao.nbti.common.auth.domain.aggregate.TempToken;
 import com.dao.nbti.common.exception.ErrorCode;
@@ -20,6 +17,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+
+import static com.dao.nbti.common.exception.ErrorCode.PASSWORD_DISCORD;
 
 @Service
 @RequiredArgsConstructor
@@ -133,5 +132,19 @@ public class AuthService {
                 .accessToken(token)
                 .refreshToken(null)
                 .build();
+    }
+
+    public void resetPassword(PasswordResetRequest request,String username) {
+        String password = request.getPassword();
+        String verifiedPassword = request.getVerifiedPassword();
+        if(!password.equals(verifiedPassword)){
+            throw new UserException(PASSWORD_DISCORD);
+        }
+
+        User user = userRepository.findByUserIdAndDeletedAtIsNull(Integer.parseInt(username)).orElseThrow(
+                () -> new UserException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        user.setPassword(passwordEncoder.encode(password));
     }
 }

--- a/NBTI/src/main/java/com/dao/nbti/common/auth/domain/aggregate/TempToken.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/auth/domain/aggregate/TempToken.java
@@ -1,0 +1,16 @@
+package com.dao.nbti.common.auth.domain.aggregate;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TempToken implements Serializable {
+    private String token;
+}

--- a/NBTI/src/main/java/com/dao/nbti/common/config/RedisConfig.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/config/RedisConfig.java
@@ -40,9 +40,9 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, RefreshToken> redisTemplate() {
+    public RedisTemplate<String, RefreshToken> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, RefreshToken> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setConnectionFactory(connectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
 //        redisTemplate.setValueSerializer(new StringRedisSerializer());
 
@@ -52,9 +52,9 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, TempToken> TempRedisTemplate() {
+    public RedisTemplate<String, TempToken> tempRedisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, TempToken> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setConnectionFactory(connectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
 //        redisTemplate.setValueSerializer(new StringRedisSerializer());
 

--- a/NBTI/src/main/java/com/dao/nbti/common/config/RedisConfig.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/config/RedisConfig.java
@@ -1,6 +1,7 @@
 package com.dao.nbti.common.config;
 
 import com.dao.nbti.common.auth.domain.aggregate.RefreshToken;
+import com.dao.nbti.common.auth.domain.aggregate.TempToken;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,6 +42,18 @@ public class RedisConfig {
     @Bean
     public RedisTemplate<String, RefreshToken> redisTemplate() {
         RedisTemplate<String, RefreshToken> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        // 값은 JSON 형태로 직렬화
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, TempToken> TempRedisTemplate() {
+        RedisTemplate<String, TempToken> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
 //        redisTemplate.setValueSerializer(new StringRedisSerializer());

--- a/NBTI/src/main/java/com/dao/nbti/common/exception/ErrorCode.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     LOGIN_ID_ALREADY_EXISTS("10001", "이미 사용중인 ID 입니다.", HttpStatus.CONFLICT),
     USER_NOT_FOUND("10002","존재하지 않는 사용자입니다.",HttpStatus.NOT_FOUND),
     INVALID_CREDENTIALS("10003", "올바르지 않은 아이디 혹은 비밀번호입니다.", HttpStatus.UNAUTHORIZED),
+    PASSWORD_DISCORD("10004","비밀번호를 다시 입력해주세요",HttpStatus.BAD_REQUEST),
 
     // 학습 관련 오류 (20001 ~ 29999)
     CATEGORY_NOT_FOUND("20001", "존재하지 않는 카테고리입니다.", HttpStatus.NOT_FOUND),

--- a/NBTI/src/main/java/com/dao/nbti/user/domain/repository/UserRepository.java
+++ b/NBTI/src/main/java/com/dao/nbti/user/domain/repository/UserRepository.java
@@ -14,4 +14,5 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
     Optional<User> findByUserIdAndDeletedAtIsNull(Integer userId);
 
+    Optional<User> findByAccountIdAndDeletedAtIsNullAndName(String accountId, String name);
 }


### PR DESCRIPTION
closes #38

---

📌 개요
사용자는 아이디와 이름을 입력하여 비밀번호를 재설정 할수 있는 권한을 가진다.
비밀번호 변경 시 토큰의 유효성을 검사한 후 비밀번호를 변경한다.
🔨 주요 변경 사항
AuthController 비밀번호 찾기, 비밀번호 재설정 메소드 추가
AuthService 비밀번호 찾기, 비밀번호 재설정 메소드 추가


✅ 리뷰 요청 사항
토큰 제공 로직 및 비밀번호 변경 로직 확인

⭐ 관련 이슈
#38 
