### PR TITLE
feat: 학습 조회 - 학습 분야 목록 조회 api 구현

### DIFF
--- a/NBTI/src/main/java/com/dao/nbti/problem/domain/repository/CategoryRepository.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/domain/repository/CategoryRepository.java
@@ -2,6 +2,12 @@ package com.dao.nbti.problem.domain.repository;
 
 import com.dao.nbti.problem.domain.aggregate.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface CategoryRepository extends JpaRepository<Category, Integer> {
+    // 상위 카테고리가 없는 (최상위) 카테고리만 조회
+    @Query(value = "SELECT * FROM category WHERE parent_category_id IS NULL", nativeQuery = true)
+    List<Category> findByParentCategoryIsNull();
 }

--- a/NBTI/src/main/java/com/dao/nbti/study/application/controller/StudyController.java
+++ b/NBTI/src/main/java/com/dao/nbti/study/application/controller/StudyController.java
@@ -4,6 +4,7 @@ import com.dao.nbti.common.dto.ApiResponse;
 import com.dao.nbti.common.exception.ErrorCode;
 import com.dao.nbti.study.application.dto.request.SubmitStudyRequestDto;
 import com.dao.nbti.study.application.dto.response.ProblemResponseDto;
+import com.dao.nbti.study.application.dto.response.StudyCategoryListResponseDto;
 import com.dao.nbti.study.application.dto.response.StudyResultDetailResponseDto;
 import com.dao.nbti.study.application.dto.response.SubmitStudyResponseDto;
 import com.dao.nbti.study.application.service.StudyService;
@@ -27,7 +28,14 @@ public class StudyController {
 
     private final StudyService studyService;
 
-    @GetMapping
+    @GetMapping("/category")
+    @Operation(summary = "학습 분야 목록 조회", description = "학습 시 선택 가능한 상위 분야 6개의 목록 및 그에 대한 설명을 제공합니다.")
+    public ResponseEntity<ApiResponse<StudyCategoryListResponseDto>> getStudyCategoryList() {
+        StudyCategoryListResponseDto studyCategoryList = studyService.getStudyCategoryList();
+        return ResponseEntity.ok(ApiResponse.success(studyCategoryList));
+    }
+
+    @GetMapping("/problem")
     @Operation(summary = "학습 문제 3개 제공", description = "선택한 분야와 난이도에 따라 3문제를 제공합니다. level=0이면 무작위 난이도입니다.")
     public ResponseEntity<ApiResponse<List<ProblemResponseDto>>> getStudyProblems(
             @RequestParam Integer categoryId,

--- a/NBTI/src/main/java/com/dao/nbti/study/application/dto/response/StudyCategoryListResponseDto.java
+++ b/NBTI/src/main/java/com/dao/nbti/study/application/dto/response/StudyCategoryListResponseDto.java
@@ -1,0 +1,43 @@
+package com.dao.nbti.study.application.dto.response;
+
+import com.dao.nbti.problem.domain.aggregate.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class StudyCategoryListResponseDto {
+    private List<CategoryDto> categories;
+
+    @Getter
+    @Builder
+    public static class CategoryDto {
+        private int categoryId;
+        private String name;
+        private String description;
+        private int timeLimit;
+
+        public static CategoryDto from(Category category) {
+            return CategoryDto.builder()
+                    .categoryId(category.getCategoryId())
+                    .name(category.getName())
+                    .description(category.getDescription())
+                    .timeLimit(category.getTimeLimit())
+                    .build();
+        }
+    }
+
+    public static StudyCategoryListResponseDto from(List<Category> categories) {
+        List<CategoryDto> dtoList = categories.stream()
+                .map(CategoryDto::from)
+                .toList();
+
+        return StudyCategoryListResponseDto.builder()
+                .categories(dtoList)
+                .build();
+    }
+
+
+}

--- a/NBTI/src/main/java/com/dao/nbti/study/application/service/StudyService.java
+++ b/NBTI/src/main/java/com/dao/nbti/study/application/service/StudyService.java
@@ -9,6 +9,7 @@ import com.dao.nbti.problem.domain.repository.CategoryRepository;
 import com.dao.nbti.problem.domain.repository.ProblemRepository;
 import com.dao.nbti.study.application.dto.request.SubmitStudyRequestDto;
 import com.dao.nbti.study.application.dto.response.ProblemResponseDto;
+import com.dao.nbti.study.application.dto.response.StudyCategoryListResponseDto;
 import com.dao.nbti.study.application.dto.response.StudyResultDetailResponseDto;
 import com.dao.nbti.study.application.dto.response.SubmitStudyResponseDto;
 import com.dao.nbti.study.domain.aggregate.IsCorrect;
@@ -41,6 +42,13 @@ public class StudyService {
     private final AnswerTypeRepository answerTypeRepository;
     private final UserRepository userRepository;
     private final PointHistoryRepository pointHistoryRepository;
+
+    @Transactional(readOnly = true)
+    public StudyCategoryListResponseDto getStudyCategoryList() {
+        List<Category> categoryList = categoryRepository.findByParentCategoryIsNull();
+
+        return StudyCategoryListResponseDto.from(categoryList);
+    }
 
     @Transactional(readOnly = true)
     public List<ProblemResponseDto> getProblems(Integer parentCategoryId, int level) {
@@ -111,6 +119,7 @@ public class StudyService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public StudyResultDetailResponseDto getStudyResultDetail(int studyId, UserDetails userDetails) {
         Study study = studyRepository.findById(studyId)
                 .orElseThrow(() -> new StudyNotFoundException(ErrorCode.STUDY_NOT_FOUND));


### PR DESCRIPTION
closes #25 

---

📌 개요
학습 조회 - 학습 분야 목록 조회 api 구현

🔨 주요 변경 사항
- 상위 카테고리에 해당하는 카테고리 정보들만 조회(parentCategory = Null인 행들만 조회)
- static method from을 통해 entity -> dto 변환 처리

⭐ 관련 이슈
#25 
