### PR TITLE
feat: 이의 제기 처리 기능 구현

### DIFF
--- a/NBTI/src/main/java/com/dao/nbti/common/exception/ErrorCode.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/exception/ErrorCode.java
@@ -32,6 +32,9 @@ public enum ErrorCode {
     UNAUTHORIZED_OBJECTION_ACCESS("40002", "본인의 이의 제기만 조회할 수 있습니다.", HttpStatus.FORBIDDEN),
     DUPLICATE_OBJECTION("40003", "이미 해당 문제에 대해 이의 제기를 제출했습니다.", HttpStatus.CONFLICT),
     INVALID_OBJECTION_TARGET("40004", "해당 문제는 사용자가 학습하지 않은 항목입니다.", HttpStatus.BAD_REQUEST),
+    OBJECTION_ALREADY_UPDATED("40005", "이미 처리 완료된 이의 제기입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_STATUS("40006", "변경할 상태는 승인 또는 반려여야 합니다.", HttpStatus.BAD_REQUEST),
+    REJECTION_REASON_REQUIRED("40007", "반려 사유를 입력해야 합니다.", HttpStatus.BAD_REQUEST),
 
     // 공통 오류
     VALIDATION_ERROR("90001", "입력 값 검증 오류입니다.", HttpStatus.BAD_REQUEST),

--- a/NBTI/src/main/java/com/dao/nbti/objection/application/controller/AdminObjectionController.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/controller/AdminObjectionController.java
@@ -2,11 +2,14 @@ package com.dao.nbti.objection.application.controller;
 
 import com.dao.nbti.common.dto.ApiResponse;
 import com.dao.nbti.objection.application.dto.request.AdminObjectionSearchRequest;
+import com.dao.nbti.objection.application.dto.request.ObjectionUpdateRequest;
 import com.dao.nbti.objection.application.dto.response.AdminObjectionDetailResponse;
 import com.dao.nbti.objection.application.dto.response.AdminObjectionListResponse;
+import com.dao.nbti.objection.application.dto.response.ObjectionUpdateResponse;
 import com.dao.nbti.objection.application.service.AdminObjectionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -34,6 +37,15 @@ public class AdminObjectionController {
             @PathVariable int objectionId
     ) {
         AdminObjectionDetailResponse objection = adminObjectionService.getObjectionDetails(objectionId);
+        return ResponseEntity.ok(ApiResponse.success(objection));
+    }
+
+    @Operation(summary = "이의 제기 처리", description = "관리자가 이의 제기를 승인 또는 반려합니다. 반려 시 사유를 반드시 입력해야 합니다.")
+    @PutMapping("/{objectionId}")
+    public ResponseEntity<ApiResponse<ObjectionUpdateResponse>> updateObjection(
+            @PathVariable int objectionId, @Valid @RequestBody ObjectionUpdateRequest objectionUpdateRequest
+    ) {
+        ObjectionUpdateResponse objection = adminObjectionService.updateObjection(objectionId, objectionUpdateRequest);
         return ResponseEntity.ok(ApiResponse.success(objection));
     }
 }

--- a/NBTI/src/main/java/com/dao/nbti/objection/application/controller/AdminObjectionController.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/controller/AdminObjectionController.java
@@ -1,12 +1,14 @@
 package com.dao.nbti.objection.application.controller;
 
 import com.dao.nbti.common.dto.ApiResponse;
+import com.dao.nbti.common.exception.ErrorCode;
 import com.dao.nbti.objection.application.dto.request.AdminObjectionSearchRequest;
 import com.dao.nbti.objection.application.dto.request.ObjectionUpdateRequest;
 import com.dao.nbti.objection.application.dto.response.AdminObjectionDetailResponse;
 import com.dao.nbti.objection.application.dto.response.AdminObjectionListResponse;
 import com.dao.nbti.objection.application.dto.response.ObjectionUpdateResponse;
 import com.dao.nbti.objection.application.service.AdminObjectionService;
+import com.dao.nbti.objection.exception.ObjectionException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -47,5 +49,13 @@ public class AdminObjectionController {
     ) {
         ObjectionUpdateResponse objection = adminObjectionService.updateObjection(objectionId, objectionUpdateRequest);
         return ResponseEntity.ok(ApiResponse.success(objection));
+    }
+
+    @ExceptionHandler(ObjectionException.class)
+    public ResponseEntity<ApiResponse<Void>> handleObjectionException(ObjectionException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.failure(errorCode.getCode(), errorCode.getMessage()));
     }
 }

--- a/NBTI/src/main/java/com/dao/nbti/objection/application/dto/request/ObjectionUpdateRequest.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/dto/request/ObjectionUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.dao.nbti.objection.application.dto.request;
+
+import com.dao.nbti.objection.domain.aggregate.Status;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ObjectionUpdateRequest {
+    private Status status;
+    private String information;
+}

--- a/NBTI/src/main/java/com/dao/nbti/objection/application/dto/response/ObjectionUpdateResponse.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/application/dto/response/ObjectionUpdateResponse.java
@@ -1,0 +1,11 @@
+package com.dao.nbti.objection.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ObjectionUpdateResponse {
+    private int objectionId;
+    private String message;
+}

--- a/NBTI/src/main/java/com/dao/nbti/objection/domain/aggregate/Objection.java
+++ b/NBTI/src/main/java/com/dao/nbti/objection/domain/aggregate/Objection.java
@@ -1,5 +1,6 @@
 package com.dao.nbti.objection.domain.aggregate;
 
+import com.dao.nbti.objection.application.dto.request.ObjectionUpdateRequest;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -41,4 +42,12 @@ public class Objection {
     private LocalDateTime processedAt;
 
     private String information;
+
+    public void updateFromRequest(ObjectionUpdateRequest objectionUpdateRequest) {
+        Status status = objectionUpdateRequest.getStatus();
+        String information = objectionUpdateRequest.getInformation();
+        this.status = status;
+        this.information = information;
+        this.processedAt = LocalDateTime.now();
+    }
 }

--- a/NBTI/src/main/java/com/dao/nbti/problem/application/controller/AdminCategoryController.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/application/controller/AdminCategoryController.java
@@ -1,0 +1,29 @@
+package com.dao.nbti.problem.application.controller;
+
+import com.dao.nbti.common.dto.ApiResponse;
+import com.dao.nbti.problem.application.dto.response.CategoryResponse;
+import com.dao.nbti.problem.application.service.AdminProblemService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/categories")
+@RequiredArgsConstructor
+@Tag(name = "문제 분야 조회", description = "관리자 문제 분야 조회 기능 API")
+public class AdminCategoryController {
+
+    private final AdminProblemService adminProblemService;
+
+    @GetMapping
+    @Operation(summary = "분야 조회", description = "관리자가 서비스에 등록된 모든 상위 분야 및 하위 분야를 조회합니다.")
+    public ResponseEntity<ApiResponse<CategoryResponse>> getCategories() {
+
+        return ResponseEntity.ok(ApiResponse.success(adminProblemService.getCategories()));
+    }
+
+}

--- a/NBTI/src/main/java/com/dao/nbti/problem/application/dto/response/CategoryResponse.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/application/dto/response/CategoryResponse.java
@@ -1,0 +1,13 @@
+package com.dao.nbti.problem.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CategoryResponse {
+    List<CategorySummaryDTO> parentCategories;
+    List<CategorySummaryDTO> childCategories;
+}

--- a/NBTI/src/main/java/com/dao/nbti/problem/application/dto/response/CategorySummaryDTO.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/application/dto/response/CategorySummaryDTO.java
@@ -1,0 +1,27 @@
+package com.dao.nbti.problem.application.dto.response;
+
+import com.dao.nbti.problem.domain.aggregate.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CategorySummaryDTO {
+    private int categoryId;
+    private Integer parentCategoryId;
+    private String name;
+
+    @Builder
+    public CategorySummaryDTO(int categoryId, Integer parentCategoryId, String name) {
+        this.categoryId = categoryId;
+        this.parentCategoryId = parentCategoryId;
+        this.name = name;
+    }
+
+    public static CategorySummaryDTO fromCategory(Category category) {
+        return CategorySummaryDTO.builder()
+                .categoryId(category.getCategoryId())
+                .parentCategoryId(category.getParentCategoryId())
+                .name(category.getName())
+                .build();
+    }
+}

--- a/NBTI/src/main/java/com/dao/nbti/problem/application/service/AdminProblemService.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/application/service/AdminProblemService.java
@@ -148,4 +148,23 @@ public class AdminProblemService {
                 .problemId(problemId)
                 .build();
     }
+
+    public CategoryResponse getCategories() {
+        List<Category> parentCategories = categoryRepository.findByParentCategoryIdIsNullOrderByCategoryIdAsc();
+
+        List<CategorySummaryDTO> parentCategoryList = parentCategories.stream()
+                .map(CategorySummaryDTO::fromCategory)
+                .toList();
+
+        List<Category> childCategories = categoryRepository.findByParentCategoryIdIsNotNullOrderByParentCategoryIdAscCategoryIdAsc();
+
+        List<CategorySummaryDTO> childCategoryList = childCategories.stream()
+                .map(CategorySummaryDTO::fromCategory)
+                .toList();
+
+        return CategoryResponse.builder()
+                .parentCategories(parentCategoryList)
+                .childCategories(childCategoryList)
+                .build();
+    }
 }

--- a/NBTI/src/main/java/com/dao/nbti/problem/domain/repository/CategoryRepository.java
+++ b/NBTI/src/main/java/com/dao/nbti/problem/domain/repository/CategoryRepository.java
@@ -3,5 +3,10 @@ package com.dao.nbti.problem.domain.repository;
 import com.dao.nbti.problem.domain.aggregate.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryRepository extends JpaRepository<Category, Integer> {
+    List<Category> findByParentCategoryIdIsNullOrderByCategoryIdAsc();
+
+    List<Category> findByParentCategoryIdIsNotNullOrderByParentCategoryIdAscCategoryIdAsc();
 }


### PR DESCRIPTION
closes #35 

---

📌 개요
- 관리자 이의 제기 처리(승인/반려) 기능 구현
🔨 주요 변경 사항
- 엔드포인트, 서비스, dto 작성
- Objection 엔터티에 update 메서드 작성
- (merge 실수) "관리자 카테고리 목록 조회"까지 함께 push됨
✅ 리뷰 요청 사항

⭐ 관련 이슈
#35 
