### PR TITLE
feat : 마이페이지에 검사 결과 저장 기능

### DIFF
--- a/NBTI/src/main/java/com/dao/nbti/common/exception/ErrorCode.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     // 검사 결과 오류 (30000 ~ 39999)
     TEST_RESULT_NOT_FOUND("30001", "검사 결과를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     UNAUTHORIZED_TEST_RESULT_ACCESS("30002", "본인의 검사 결과만 조회할 수 있습니다.", HttpStatus.FORBIDDEN),
+    AI_CALL_FAILED("30003", "ai 호출에 실패했습니다.", HttpStatus.BAD_GATEWAY),
 
     // 이의 제기 오류 (40000 ~ 49999)
     OBJECTION_NOT_FOUND("40001", "이의 제기 항목을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/NBTI/src/main/java/com/dao/nbti/common/exception/GlobalExceptionHandler.java
+++ b/NBTI/src/main/java/com/dao/nbti/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.dao.nbti.common.exception;
 
 
 import com.dao.nbti.common.dto.ApiResponse;
+import com.dao.nbti.test.exception.TestException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -24,6 +25,17 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, errorCode.getHttpStatus());
     }
 
+    @ExceptionHandler(TestException.class)
+    public ResponseEntity<ApiResponse> handleAuthorNotFoundException(TestException e){
+        ErrorCode errorCode = e.getErrorCode();
+
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
+
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+    }
+
+    
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ApiResponse<Void>> handleException(RuntimeException e) {
         ErrorCode errorCode = ErrorCode.UNKNOWN_RUNTIME_ERROR;

--- a/NBTI/src/main/java/com/dao/nbti/test/application/controller/TestController.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/controller/TestController.java
@@ -36,4 +36,19 @@ public class TestController {
 
         return ResponseEntity.ok(ApiResponse.success(null));
     }
+
+    /* 검사 결과 마이페이지에 저장하기 */
+    @PutMapping("/result/my-page")
+    @Operation(
+            summary = "지능 검사 결과 마이페이지에 저장하기", description = "회원의 지능 검사 결과를 마이페이지에 저장합니다."
+    )
+    public ResponseEntity<ApiResponse<Void>> updateTestResult(
+            @AuthenticationPrincipal User user
+    ){
+
+        // 로그인 된 회원만 바꿀 수 있음
+        testService.updateTestResult(user.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
 }

--- a/NBTI/src/main/java/com/dao/nbti/test/application/service/TestAiAnswerServiceImpl.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/service/TestAiAnswerServiceImpl.java
@@ -1,6 +1,8 @@
 package com.dao.nbti.test.application.service;
 
+import com.dao.nbti.common.exception.ErrorCode;
 import com.dao.nbti.test.application.dto.request.TestResultCreateRequest;
+import com.dao.nbti.test.exception.TestException;
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
 import com.openai.models.ChatModel;
@@ -45,10 +47,13 @@ public class TestAiAnswerServiceImpl implements TestAiAnswerService{
 
 
         // 응답 결과 객체 : 채팅 기반 모델을 사용해 메시지 기반으로 응답 (AI 호출하기)
-        ChatCompletion completion = client.chat().completions().create(params);
-
-        // AI 에게 응답 받은 거 생성하기
-        return completion.choices().get(0).message().content().orElse("").trim();
+        try {
+            ChatCompletion completion = client.chat().completions().create(params);
+            return completion.choices().get(0).message().content().orElse("").trim();
+        } catch (Exception e) {
+            // ai 호출 시 발생하는 에러
+            throw new TestException(ErrorCode.AI_CALL_FAILED);
+        }
     }
 
     /* 프롬포트 만들기 */

--- a/NBTI/src/main/java/com/dao/nbti/test/application/service/TestService.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/service/TestService.java
@@ -6,4 +6,6 @@ public interface TestService {
 
     void createTestResult(TestResultCreateRequest testResultCreateRequest, Integer userId);
 
+    void updateTestResult(Integer userId);
+
 }

--- a/NBTI/src/main/java/com/dao/nbti/test/application/service/TestServiceImpl.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/service/TestServiceImpl.java
@@ -1,9 +1,15 @@
 package com.dao.nbti.test.application.service;
 
+import com.dao.nbti.common.exception.ErrorCode;
 import com.dao.nbti.test.application.dto.request.TestResultCreateRequest;
+import com.dao.nbti.test.domain.aggregate.IsSaved;
 import com.dao.nbti.test.domain.aggregate.TestResult;
 import com.dao.nbti.test.domain.repository.TestProblemRepository;
 import com.dao.nbti.test.domain.repository.TestResultRepository;
+import com.dao.nbti.test.exception.TestException;
+import com.dao.nbti.user.domain.aggregate.User;
+import com.dao.nbti.user.domain.repository.UserRepository;
+import com.dao.nbti.user.exception.UserException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +24,7 @@ public class TestServiceImpl implements TestService {
     private final TestResultRepository testResultRepository;
     private final TestProblemRepository testProblemRepository;
     private final TestAiAnswerService testAiAnswerService;
+    private final UserRepository userRepository;
 
     /* 검사 결과 생성하기*/
     @Transactional
@@ -43,4 +50,22 @@ public class TestServiceImpl implements TestService {
         testResultRepository.save(testResult);
     }
 
+    /* 마이페이지에 검사 결과 저장하기*/
+    @Transactional
+    public void updateTestResult(Integer userId) {
+
+        // userId 가져오기 (로그인 된 user의 Id)
+        // user가 있는지 확인하기
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        log.info("userId: {}", user.getUserId());
+
+        // 검사 결과 가져오기
+        TestResult testResult = testResultRepository.findLatestByUserId(userId)
+                .orElseThrow(() -> new TestException(ErrorCode.TEST_RESULT_NOT_FOUND));
+
+        // 검사 결과 수정하기
+        testResult.saveToMyPage();
+    }
 }

--- a/NBTI/src/main/java/com/dao/nbti/test/domain/aggregate/TestResult.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/domain/aggregate/TestResult.java
@@ -46,6 +46,7 @@ public class TestResult {
     private LocalDateTime createdAt = LocalDateTime.now();
 
     @Column(name = "is_saved")
+    @Enumerated(EnumType.STRING)
     private IsSaved isSaved = IsSaved.N;
 
     @Builder
@@ -62,7 +63,7 @@ public class TestResult {
         this.spatialPerception = spatialPerception;
         this.aiText = aiText;
         this.createdAt = createdAt;
-        this.isSaved = isSaved;
+        this.isSaved = isSaved != null ? isSaved : IsSaved.N;
     }
 
     public void saveToMyPage() {

--- a/NBTI/src/main/java/com/dao/nbti/test/domain/repository/TestResultRepository.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/domain/repository/TestResultRepository.java
@@ -33,4 +33,13 @@ public interface TestResultRepository extends JpaRepository<TestResult, Integer>
             @Param("month") Integer month,
             Pageable pageable
     );
+
+    @Query(value = """
+        SELECT *
+        FROM test_result
+        WHERE user_id = :userId
+        ORDER BY created_at DESC
+        LIMIT 1
+    """, nativeQuery = true)
+    Optional<TestResult> findLatestByUserId(@Param("userId") int userId);
 }

--- a/NBTI/src/main/java/com/dao/nbti/user/domain/repository/UserRepository.java
+++ b/NBTI/src/main/java/com/dao/nbti/user/domain/repository/UserRepository.java
@@ -15,4 +15,7 @@ public interface UserRepository extends JpaRepository<User, Integer> {
     Optional<User> findByUserIdAndDeletedAtIsNull(Integer userId);
 
     Optional<User> findByAccountIdAndDeletedAtIsNullAndName(String accountId, String name);
+
+    Optional<User> findByUserId(Integer userId);
+
 }

--- a/NBTI/src/test/java/com/dao/nbti/test/application/service/TestServiceImplTest.java
+++ b/NBTI/src/test/java/com/dao/nbti/test/application/service/TestServiceImplTest.java
@@ -1,0 +1,67 @@
+package com.dao.nbti.test.application.service;
+
+import com.dao.nbti.test.application.dto.request.TestResultCreateRequest;
+import com.dao.nbti.test.domain.repository.TestProblemRepository;
+import com.dao.nbti.test.domain.repository.TestResultRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TestServiceImplTest {
+
+    @Mock
+    private TestResultRepository testResultRepository;
+
+    @Mock
+    private TestProblemRepository testProblemRepository;
+
+    @Mock
+    private TestAiAnswerService testAiAnswerService;
+
+    @InjectMocks
+    private TestServiceImpl testService;
+
+    @Test
+    void createTestResult() {
+        Integer userId = 1;
+        TestResultCreateRequest request = new TestResultCreateRequest
+                (4, 5, 3, 6, 2, 1);
+
+        String aiText = "당신은 논리적인 사고가 뛰어납니다.";
+        Mockito.when(testAiAnswerService.createAiAnswer(request)).thenReturn(aiText);
+
+        testService.createTestResult(request, userId);
+
+        // times(1) 을 통해 메서드가 1번 실행되엇는지 점검
+        Mockito.verify(testResultRepository, Mockito.times(1)).save(Mockito.argThat(testResult ->
+                testResult.getUserId().equals(userId)
+                        && testResult.getAiText().equals(aiText)
+                        && testResult.getLangComp() == 4
+                        && testResult.getGeneralKnowledge() == 5
+        ));
+    }
+
+    @Test
+    void saveTestResult() {
+        Integer userId = 1;
+        TestResultCreateRequest request = new TestResultCreateRequest(4, 5, 3, 6, 2, 1); // 생성자 또는 빌더로 채워줘야 함
+
+        String aiText = "당신은 논리적인 사고가 뛰어납니다.";
+        Mockito.when(testAiAnswerService.createAiAnswer(request)).thenReturn(aiText);
+
+        testService.createTestResult(request, userId);
+
+        Mockito.verify(testResultRepository, Mockito.times(1)).save(Mockito.argThat(testResult ->
+                testResult.getUserId().equals(userId)
+                        && testResult.getAiText().equals(aiText)
+                        && testResult.getLangComp() == 4
+                        && testResult.getGeneralKnowledge() == 5
+        ));
+    }
+
+
+}


### PR DESCRIPTION
closes #61

---

📌 개요
마이페이지에 검사 결과 저장 기능 구현

🔨 주요 변경 사항
- ErrorCode 생성 및 Error 핸들링 하기
- 마이페이지에 검사 결과 저장하기
	- `TestController`에 응답 받기 (추후에 User 부분은 수정 예정)
	- `TestService, TestServiceImpl` 에 회원의 게시글 저장 추가하기
	- `TestResultRepository`에 해당 회원의 가장 마지막 게시글 조회 메서드추가 
- 'TestAiService, TestAiServiceImpl`에 예외 처리 추가하기
- `TestResult`에 IsSaved 속성 수정
- 서비스 단위 테스트 완료

✅ 리뷰 요청 사항

⭐ 관련 이슈
#61