### PR TITLE
feat: 회원 목록 조회 기능 구현

### DIFF
--- a/NBTI/src/main/java/com/dao/nbti/user/application/controller/UserController.java
+++ b/NBTI/src/main/java/com/dao/nbti/user/application/controller/UserController.java
@@ -2,14 +2,15 @@ package com.dao.nbti.user.application.controller;
 
 import com.dao.nbti.common.dto.ApiResponse;
 import com.dao.nbti.common.exception.ErrorCode;
-import com.dao.nbti.user.application.dto.IdDuplicateResponse;
-import com.dao.nbti.user.application.dto.UserCreateRequest;
-import com.dao.nbti.user.application.dto.UserInfoResponse;
+import com.dao.nbti.user.application.dto.*;
 import com.dao.nbti.user.application.service.UserService;
+import com.dao.nbti.user.domain.aggregate.IsDeleted;
 import com.dao.nbti.user.exception.UserException;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -49,6 +50,17 @@ public class UserController {
     @GetMapping("/info")
     public ResponseEntity<ApiResponse<UserInfoResponse>> getUserInfo(@AuthenticationPrincipal UserDetails userDetails){
         UserInfoResponse response = userService.getUserInfo(userDetails.getUsername());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "회원 목록 조회", description = "관리자는 전체 회원 목록을 조회하고 필터/검색 기능을 이용할 수 있다.")
+    @GetMapping("/list")
+    public ResponseEntity<ApiResponse<UserAdminViewResponse>> getUserList(
+            @RequestParam(required = false) String accountId,
+            @RequestParam(required = false) String isDeleted,
+            @PageableDefault(sort="userId") Pageable pageable){
+        UserSearchCondition condition = new UserSearchCondition(accountId,IsDeleted.valueOf(isDeleted));
+        UserAdminViewResponse response = userService.getUserList(condition, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/NBTI/src/main/java/com/dao/nbti/user/application/dto/UserAdminViewDTO.java
+++ b/NBTI/src/main/java/com/dao/nbti/user/application/dto/UserAdminViewDTO.java
@@ -1,0 +1,21 @@
+package com.dao.nbti.user.application.dto;
+
+import com.dao.nbti.user.domain.aggregate.Gender;
+import com.dao.nbti.user.domain.aggregate.IsDeleted;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserAdminViewDTO {
+    private String accountId;
+    private String name;
+    private Gender gender;
+    private LocalDate birthdate;
+    private int point;
+    private IsDeleted isDeleted;
+}

--- a/NBTI/src/main/java/com/dao/nbti/user/application/dto/UserAdminViewResponse.java
+++ b/NBTI/src/main/java/com/dao/nbti/user/application/dto/UserAdminViewResponse.java
@@ -1,0 +1,13 @@
+package com.dao.nbti.user.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserAdminViewResponse {
+    private Page<UserAdminViewDTO> page;
+}

--- a/NBTI/src/main/java/com/dao/nbti/user/application/dto/UserSearchCondition.java
+++ b/NBTI/src/main/java/com/dao/nbti/user/application/dto/UserSearchCondition.java
@@ -1,0 +1,12 @@
+package com.dao.nbti.user.application.dto;
+
+import com.dao.nbti.user.domain.aggregate.IsDeleted;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserSearchCondition {
+    private String accountId;
+    private IsDeleted isDeleted;
+}

--- a/NBTI/src/main/java/com/dao/nbti/user/domain/repository/UserRepositoryCustom.java
+++ b/NBTI/src/main/java/com/dao/nbti/user/domain/repository/UserRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.dao.nbti.user.domain.repository;
+
+import com.dao.nbti.user.application.dto.UserSearchCondition;
+import com.dao.nbti.user.domain.aggregate.User;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface UserRepositoryCustom {
+    List<User> getUsers(UserSearchCondition condition, Pageable pageable);
+
+    long countUsers(UserSearchCondition condition);
+}

--- a/NBTI/src/main/java/com/dao/nbti/user/domain/repository/UserRepositoryCustomImpl.java
+++ b/NBTI/src/main/java/com/dao/nbti/user/domain/repository/UserRepositoryCustomImpl.java
@@ -1,0 +1,75 @@
+package com.dao.nbti.user.domain.repository;
+
+
+import com.dao.nbti.user.application.dto.UserSearchCondition;
+import com.dao.nbti.user.domain.aggregate.User;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Slf4j
+@Repository
+public class UserRepositoryCustomImpl implements UserRepositoryCustom{
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public List<User> getUsers(UserSearchCondition condition, Pageable pageable) {
+        String initQuery = """
+               SELECT u FROM User u WHERE 1=1
+               """;
+        String jpql = getDynamicQuery(initQuery, condition);
+        TypedQuery<User> query = em.createQuery(jpql, User.class);
+
+        if (condition.getAccountId() != null) {
+            log.info("{}",condition.getAccountId());
+            query.setParameter("accountId",condition.getAccountId());
+        }
+        if(condition.getIsDeleted()!=null){
+            query.setParameter("isDeleted",condition.getIsDeleted());
+        }
+
+        //페이징 처리 적용
+        query.setFirstResult((int) pageable.getOffset()); // 시작 위치 (ex: 0, 10, 20...)
+        query.setMaxResults(pageable.getPageSize());      // 페이지당 개수
+
+        return query.getResultList();
+    }
+
+    @Override
+    public long countUsers(UserSearchCondition condition) {
+        String initQuery = """
+               SELECT count(u) FROM User u WHERE 1=1
+                """;
+        String jpql = getDynamicQuery(initQuery, condition);
+        TypedQuery<Long> query = em.createQuery(jpql, Long.class);
+
+        if (condition.getAccountId() != null) {
+            query.setParameter("accountId",condition.getAccountId());
+        }
+        if(condition.getIsDeleted()!=null){
+            query.setParameter("isDeleted",condition.getIsDeleted());
+        }
+
+        return query.getSingleResult();
+    }
+
+    private static String getDynamicQuery(String str, UserSearchCondition condition) {
+        StringBuilder jpql = new StringBuilder(str);
+
+        if (condition.getAccountId() != null) {
+            jpql.append("\nAND u.accountId = :accountId");
+        }
+
+        if (condition.getIsDeleted() != null) {
+            jpql.append("\nAND u.isDeleted = :isDeleted");
+        }
+
+        return jpql.toString();
+    }
+}


### PR DESCRIPTION
closes #44

---

📌 개요
커밋 이슈 번호를 잘못 적었습니다;;
🔨 주요 변경 사항
회원 목록 조회 구현
검색하려는 사용자 Id, 탈퇴여부를 검색조건으로 사용할 수 있으며
검색 후 Page를 담은 response를 반환한다.

✅ 리뷰 요청 사항
회원 목록 조회 로직 확인


⭐ 관련 이슈
#44
