### PR TITLE
feat: 관리자 검사 내역 조회 기능 구현

### DIFF
--- a/NBTI/src/main/java/com/dao/nbti/test/application/controller/TestResultController.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/controller/TestResultController.java
@@ -7,6 +7,7 @@ import com.dao.nbti.test.application.dto.response.AdminTestResultSummaryResponse
 import com.dao.nbti.test.application.dto.response.TestResultDetailResponse;
 import com.dao.nbti.test.application.dto.request.TestResultSearchCondition;
 import com.dao.nbti.test.application.dto.response.TestResultSummaryResponse;
+import com.dao.nbti.test.application.service.AdminTestResultService;
 import com.dao.nbti.test.application.service.TestResultService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -29,6 +30,7 @@ import java.util.Map;
 public class TestResultController {
 
     private final TestResultService testResultService;
+    private final AdminTestResultService adminTestResultService;
 
     @Operation(summary = "검사 결과 목록 조회", description = "로그인한 사용자의 검사 결과 목록을 조회합니다. 연도/월별 필터링 및 페이지네이션이 가능합니다.")
     @GetMapping("/list")
@@ -92,7 +94,7 @@ public class TestResultController {
     ) {
         AdminTestResultSearchCondition condition = new AdminTestResultSearchCondition(year, month, accountId);
 
-        AdminTestResultSummaryResponse resultPage = testResultService.getAdminTestResultList(condition, pageable);
+        AdminTestResultSummaryResponse resultPage = adminTestResultService.getAdminTestResultList(condition, pageable);
 
         Map<String, Object> response = new HashMap<>();
         response.put("content", resultPage.getPage().getContent());
@@ -101,6 +103,17 @@ public class TestResultController {
                 .totalPage(resultPage.getPage().getTotalPages())
                 .totalItems(resultPage.getPage().getTotalElements())
                 .build());
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "관리자 검사 상세조회", description = "검사 결과 ID를 통해 상세 정보를 조회합니다.")
+    @GetMapping("/{testResultId}/admin")
+    public ResponseEntity<ApiResponse<TestResultDetailResponse>> getTestResultDetail(
+            @Parameter(description = "검사 결과 ID", example = "1")
+            @PathVariable int testResultId
+    ){
+        TestResultDetailResponse response = adminTestResultService.getTestResultDetail(testResultId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/NBTI/src/main/java/com/dao/nbti/test/application/controller/TestResultController.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/controller/TestResultController.java
@@ -2,6 +2,8 @@ package com.dao.nbti.test.application.controller;
 
 import com.dao.nbti.common.dto.ApiResponse;
 import com.dao.nbti.common.dto.Pagination;
+import com.dao.nbti.test.application.dto.request.AdminTestResultSearchCondition;
+import com.dao.nbti.test.application.dto.response.AdminTestResultSummaryResponse;
 import com.dao.nbti.test.application.dto.response.TestResultDetailResponse;
 import com.dao.nbti.test.application.dto.request.TestResultSearchCondition;
 import com.dao.nbti.test.application.dto.response.TestResultSummaryResponse;
@@ -71,5 +73,35 @@ public class TestResultController {
     ) {
         TestResultDetailResponse detail = testResultService.getTestResultDetail(testResultId, userId);
         return ResponseEntity.ok(ApiResponse.success(detail));
+    }
+
+    @Operation(summary = "검사 목록 조회", description = "검사 결과 ID를 통해 상세 정보를 조회합니다.")
+    @GetMapping("/list/admin")
+    public ResponseEntity<ApiResponse<Map<String,Object>>> getTestResults(
+            @Parameter(description = "사용자 id", example="user01")
+            @RequestParam(required = false) String accountId,
+
+            @Parameter(description = "조회할 연도", example = "2025")
+            @RequestParam(required = false) Integer year,
+
+            @Parameter(description = "조회할 월 (1~12)", example = "5")
+            @RequestParam(required = false) Integer month,
+
+            @Parameter(description = "페이지 및 정렬 정보")
+            @PageableDefault(size = 10, sort = "createdAt") Pageable pageable
+    ) {
+        AdminTestResultSearchCondition condition = new AdminTestResultSearchCondition(year, month, accountId);
+
+        AdminTestResultSummaryResponse resultPage = testResultService.getAdminTestResultList(condition, pageable);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("content", resultPage.getPage().getContent());
+        response.put("pagination", Pagination.builder()
+                .currentPage(resultPage.getPage().getNumber() + 1)
+                .totalPage(resultPage.getPage().getTotalPages())
+                .totalItems(resultPage.getPage().getTotalElements())
+                .build());
+
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/NBTI/src/main/java/com/dao/nbti/test/application/dto/request/AdminTestResultSearchCondition.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/dto/request/AdminTestResultSearchCondition.java
@@ -1,0 +1,12 @@
+package com.dao.nbti.test.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminTestResultSearchCondition {
+    private Integer year;
+    private Integer month;
+    private String accountId;
+}

--- a/NBTI/src/main/java/com/dao/nbti/test/application/dto/response/AccountTestResultDto.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/dto/response/AccountTestResultDto.java
@@ -1,0 +1,14 @@
+package com.dao.nbti.test.application.dto.response;
+
+import com.dao.nbti.test.domain.aggregate.TestResult;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountTestResultDto {
+    private String accountId;
+    private TestResult testResult;
+}

--- a/NBTI/src/main/java/com/dao/nbti/test/application/dto/response/AdminTestResultSummaryDTO.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/dto/response/AdminTestResultSummaryDTO.java
@@ -1,0 +1,20 @@
+package com.dao.nbti.test.application.dto.response;
+
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class AdminTestResultSummaryDTO {
+    private int testResultId;
+    private String accountId;
+    private LocalDateTime createdAt;
+    private String highestCategory;
+    private String lowestCategory;
+    private int totalScore;
+
+    public void setAccountId(String accountId){
+        this.accountId = accountId;
+    }
+}

--- a/NBTI/src/main/java/com/dao/nbti/test/application/dto/response/AdminTestResultSummaryResponse.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/dto/response/AdminTestResultSummaryResponse.java
@@ -1,0 +1,12 @@
+package com.dao.nbti.test.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@AllArgsConstructor
+public class AdminTestResultSummaryResponse {
+    Page<AdminTestResultSummaryDTO> page;
+
+}

--- a/NBTI/src/main/java/com/dao/nbti/test/application/service/AdminTestResultService.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/service/AdminTestResultService.java
@@ -1,0 +1,11 @@
+package com.dao.nbti.test.application.service;
+
+import com.dao.nbti.test.application.dto.request.AdminTestResultSearchCondition;
+import com.dao.nbti.test.application.dto.response.AdminTestResultSummaryResponse;
+import com.dao.nbti.test.application.dto.response.TestResultDetailResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface AdminTestResultService {
+    AdminTestResultSummaryResponse getAdminTestResultList(AdminTestResultSearchCondition condition, Pageable pageable);
+    TestResultDetailResponse getTestResultDetail(int testResultId);
+}

--- a/NBTI/src/main/java/com/dao/nbti/test/application/service/AdminTestResultServiceImpl.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/service/AdminTestResultServiceImpl.java
@@ -1,0 +1,118 @@
+package com.dao.nbti.test.application.service;
+
+import com.dao.nbti.common.exception.ErrorCode;
+import com.dao.nbti.problem.domain.aggregate.Category;
+import com.dao.nbti.problem.domain.repository.CategoryRepository;
+import com.dao.nbti.test.application.dto.request.AdminTestResultSearchCondition;
+import com.dao.nbti.test.application.dto.response.*;
+import com.dao.nbti.test.domain.aggregate.TestResult;
+import com.dao.nbti.test.domain.repository.TestRepositoryCustom;
+import com.dao.nbti.test.domain.repository.TestResultRepository;
+import com.dao.nbti.test.exception.TestException;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminTestResultServiceImpl implements AdminTestResultService{
+    private final TestResultRepository testResultRepository;
+    private final CategoryRepository categoryRepository;
+    private final TestRepositoryCustom testRepositoryCustom;
+    private final ModelMapper modelMapper;
+
+
+    @Override
+    public AdminTestResultSummaryResponse getAdminTestResultList(AdminTestResultSearchCondition condition, Pageable pageable) {
+        List<AccountTestResultDto> results = testRepositoryCustom.getTest(condition,pageable);
+        List<AdminTestResultSummaryDTO> content = results.stream()
+                .map(dto -> {
+                    AdminTestResultSummaryDTO adminTestResultSummaryDTO= modelMapper.map(
+                            toSummaryResponse(dto.getTestResult()), AdminTestResultSummaryDTO.class
+                    );
+                    adminTestResultSummaryDTO.setAccountId(dto.getAccountId());
+                    return adminTestResultSummaryDTO;
+                }).toList();
+        long total = testRepositoryCustom.countTest(condition);
+        return new AdminTestResultSummaryResponse(new PageImpl<>(content, pageable, total));
+    }
+
+    @Override
+    public TestResultDetailResponse getTestResultDetail(int testResultId) {
+        TestResult testResult = testResultRepository.findByTestResultId(testResultId)
+                .orElseThrow(() -> new TestException(ErrorCode.TEST_RESULT_NOT_FOUND));
+
+        return toDetailResponse(testResult);
+    }
+
+    private TestResultSummaryResponse toSummaryResponse(TestResult result) {
+        int[] scores = {
+                result.getLangComp(),
+                result.getGeneralKnowledge(),
+                result.getPercReason(),
+                result.getWorkMemory(),
+                result.getProcSpeed(),
+                result.getSpatialPerception()
+        };
+        String[] categories = {
+                "언어 이해", "시사 상식", "지각 추론", "작업 기억", "처리 속도", "공간 지각력"
+        };
+
+        int maxIdx = 0, minIdx = 0;
+        for (int i = 1; i < scores.length; i++) {
+            if (scores[i] > scores[maxIdx]) maxIdx = i;
+            if (scores[i] < scores[minIdx]) minIdx = i;
+        }
+
+        int totalScore = (int) Math.round(
+                (scores[0] + scores[1] + scores[2] + scores[3] + scores[4] + scores[5]) / 6.0
+        );
+
+        return TestResultSummaryResponse.builder()
+                .testResultId(result.getTestResultId())
+                .createdAt(result.getCreatedAt())
+                .highestCategory(categories[maxIdx])
+                .lowestCategory(categories[minIdx])
+                .totalScore(totalScore)
+                .build();
+    }
+
+    private TestResultDetailResponse toDetailResponse(TestResult result) {
+        List<String> categoryNames = List.of(
+                "언어 이해", "시사 상식", "지각 추론", "작업 기억", "처리 속도", "공간 지각력"
+        );
+
+        Map<String, String> descriptionMap = categoryRepository.findAll().stream()
+                .filter(c -> c.getParentCategoryId() == null && categoryNames.contains(c.getName()))
+                .collect(Collectors.toMap(Category::getName, Category::getDescription));
+
+        List<CategoryScoreDetail> scores = List.of(
+                newScoreDetail("언어 이해", result.getLangComp(), descriptionMap),
+                newScoreDetail("시사 상식", result.getGeneralKnowledge(), descriptionMap),
+                newScoreDetail("지각 추론", result.getPercReason(), descriptionMap),
+                newScoreDetail("작업 기억", result.getWorkMemory(), descriptionMap),
+                newScoreDetail("처리 속도", result.getProcSpeed(), descriptionMap),
+                newScoreDetail("공간 지각력", result.getSpatialPerception(), descriptionMap)
+        );
+
+        return TestResultDetailResponse.builder()
+                .scores(scores)
+                .aiText(result.getAiText())
+                .createdAt(result.getCreatedAt())
+                .build();
+    }
+
+    private CategoryScoreDetail newScoreDetail(String name, int score, Map<String, String> descMap) {
+        return CategoryScoreDetail.builder()
+                .categoryName(name)
+                .description(descMap.getOrDefault(name, ""))
+                .score(score)
+                .build();
+    }
+}

--- a/NBTI/src/main/java/com/dao/nbti/test/application/service/TestResultService.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/service/TestResultService.java
@@ -1,8 +1,6 @@
 package com.dao.nbti.test.application.service;
 
-import com.dao.nbti.test.application.dto.request.AdminTestResultSearchCondition;
 import com.dao.nbti.test.application.dto.request.TestResultSearchCondition;
-import com.dao.nbti.test.application.dto.response.AdminTestResultSummaryResponse;
 import com.dao.nbti.test.application.dto.response.TestResultDetailResponse;
 import com.dao.nbti.test.application.dto.response.TestResultSummaryResponse;
 import org.springframework.data.domain.Page;
@@ -11,5 +9,4 @@ import org.springframework.data.domain.Pageable;
 public interface TestResultService {
     Page<TestResultSummaryResponse> getTestResultList(TestResultSearchCondition condition, Pageable pageable);
     TestResultDetailResponse getTestResultDetail(int testResultId, int userId);
-    AdminTestResultSummaryResponse getAdminTestResultList(AdminTestResultSearchCondition condition, Pageable pageable);
 }

--- a/NBTI/src/main/java/com/dao/nbti/test/application/service/TestResultService.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/service/TestResultService.java
@@ -1,6 +1,8 @@
 package com.dao.nbti.test.application.service;
 
+import com.dao.nbti.test.application.dto.request.AdminTestResultSearchCondition;
 import com.dao.nbti.test.application.dto.request.TestResultSearchCondition;
+import com.dao.nbti.test.application.dto.response.AdminTestResultSummaryResponse;
 import com.dao.nbti.test.application.dto.response.TestResultDetailResponse;
 import com.dao.nbti.test.application.dto.response.TestResultSummaryResponse;
 import org.springframework.data.domain.Page;
@@ -9,4 +11,5 @@ import org.springframework.data.domain.Pageable;
 public interface TestResultService {
     Page<TestResultSummaryResponse> getTestResultList(TestResultSearchCondition condition, Pageable pageable);
     TestResultDetailResponse getTestResultDetail(int testResultId, int userId);
+    AdminTestResultSummaryResponse getAdminTestResultList(AdminTestResultSearchCondition condition, Pageable pageable);
 }

--- a/NBTI/src/main/java/com/dao/nbti/test/application/service/TestResultServiceImpl.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/application/service/TestResultServiceImpl.java
@@ -3,18 +3,15 @@ package com.dao.nbti.test.application.service;
 import com.dao.nbti.common.exception.ErrorCode;
 import com.dao.nbti.problem.domain.aggregate.Category;
 import com.dao.nbti.problem.domain.repository.CategoryRepository;
-import com.dao.nbti.test.application.dto.request.AdminTestResultSearchCondition;
 import com.dao.nbti.test.application.dto.request.TestResultSearchCondition;
 import com.dao.nbti.test.application.dto.response.*;
 import com.dao.nbti.test.domain.aggregate.TestResult;
 import com.dao.nbti.test.domain.repository.TestRepositoryCustom;
 import com.dao.nbti.test.domain.repository.TestResultRepository;
 import com.dao.nbti.test.exception.TestException;
-import com.dao.nbti.user.application.dto.UserAdminViewResponse;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -51,20 +48,6 @@ public class TestResultServiceImpl implements TestResultService {
         return toDetailResponse(result);
     }
 
-    @Override
-    public AdminTestResultSummaryResponse getAdminTestResultList(AdminTestResultSearchCondition condition, Pageable pageable) {
-        List<AccountTestResultDto> results = testRepositoryCustom.getTest(condition,pageable);
-        List<AdminTestResultSummaryDTO> content = results.stream()
-                .map(dto -> {
-                    AdminTestResultSummaryDTO adminTestResultSummaryDTO= modelMapper.map(
-                            toSummaryResponse(dto.getTestResult()), AdminTestResultSummaryDTO.class
-                    );
-                    adminTestResultSummaryDTO.setAccountId(dto.getAccountId());
-                    return adminTestResultSummaryDTO;
-                }).toList();
-        long total = testRepositoryCustom.countTest(condition);
-        return new AdminTestResultSummaryResponse(new PageImpl<>(content, pageable, total));
-    }
 
     private TestResultSummaryResponse toSummaryResponse(TestResult result) {
         int[] scores = {

--- a/NBTI/src/main/java/com/dao/nbti/test/domain/repository/TestRepositoryCustom.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/domain/repository/TestRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.dao.nbti.test.domain.repository;
+
+import com.dao.nbti.test.application.dto.request.AdminTestResultSearchCondition;
+import com.dao.nbti.test.application.dto.response.AccountTestResultDto;
+
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface TestRepositoryCustom {
+    List<AccountTestResultDto> getTest(AdminTestResultSearchCondition condition, Pageable pageable);
+
+    long countTest(AdminTestResultSearchCondition condition);
+}

--- a/NBTI/src/main/java/com/dao/nbti/test/domain/repository/TestRepositoryCustomImpl.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/domain/repository/TestRepositoryCustomImpl.java
@@ -31,7 +31,7 @@ public class TestRepositoryCustomImpl implements TestRepositoryCustom {
         TypedQuery<AccountTestResultDto> query = em.createQuery(jpql, AccountTestResultDto.class);
 
         if (condition.getYear() != null) {
-            query.setParameter("yaer",condition.getYear());
+            query.setParameter("year",condition.getYear());
         }
 
         if (condition.getMonth() != null) {
@@ -60,7 +60,7 @@ public class TestRepositoryCustomImpl implements TestRepositoryCustom {
         TypedQuery<Long> query = em.createQuery(jpql, Long.class);
 
         if (condition.getYear() != null) {
-            query.setParameter("yaer",condition.getYear());
+            query.setParameter("year",condition.getYear());
         }
 
         if (condition.getMonth() != null) {

--- a/NBTI/src/main/java/com/dao/nbti/test/domain/repository/TestRepositoryCustomImpl.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/domain/repository/TestRepositoryCustomImpl.java
@@ -1,0 +1,92 @@
+package com.dao.nbti.test.domain.repository;
+
+
+import com.dao.nbti.test.application.dto.request.AdminTestResultSearchCondition;
+import com.dao.nbti.test.application.dto.response.AccountTestResultDto;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Slf4j
+@Repository
+public class TestRepositoryCustomImpl implements TestRepositoryCustom {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public List<AccountTestResultDto> getTest(AdminTestResultSearchCondition condition, Pageable pageable) {
+        String initQuery = """
+               SELECT new com.dao.nbti.test.application.dto.response.AccountTestResultDto(u.accountId, tr)
+               FROM TestResult tr
+               JOIN User u
+               ON u.userId = tr.userId
+               WHERE 1=1
+               """;
+        String jpql = getDynamicQuery(initQuery, condition);
+        TypedQuery<AccountTestResultDto> query = em.createQuery(jpql, AccountTestResultDto.class);
+
+        if (condition.getYear() != null) {
+            query.setParameter("yaer",condition.getYear());
+        }
+
+        if (condition.getMonth() != null) {
+            query.setParameter("month",condition.getMonth());
+        }
+        if(condition.getAccountId()!=null){
+            query.setParameter("accountId",condition.getAccountId());
+        }
+        //페이징 처리 적용
+        query.setFirstResult((int) pageable.getOffset()); // 시작 위치 (ex: 0, 10, 20...)
+        query.setMaxResults(pageable.getPageSize());      // 페이지당 개수
+
+        return query.getResultList();
+    }
+
+    @Override
+    public long countTest(AdminTestResultSearchCondition condition) {
+        String initQuery = """
+               SELECT count(*)
+               FROM TestResult tr
+               JOIN User u
+               ON u.userId = tr.userId
+               WHERE 1=1
+               """;
+        String jpql = getDynamicQuery(initQuery, condition);
+        TypedQuery<Long> query = em.createQuery(jpql, Long.class);
+
+        if (condition.getYear() != null) {
+            query.setParameter("yaer",condition.getYear());
+        }
+
+        if (condition.getMonth() != null) {
+            query.setParameter("month",condition.getMonth());
+        }
+        if(condition.getAccountId()!=null){
+            query.setParameter("accountId",condition.getAccountId());
+        }
+
+        return query.getSingleResult();
+    }
+
+    private static String getDynamicQuery(String str, AdminTestResultSearchCondition condition) {
+        StringBuilder jpql = new StringBuilder(str);
+
+        if (condition.getYear() != null) {
+            jpql.append("\nAND FUNCTION('YEAR', tr.createdAt) = :year)");
+        }
+
+        if (condition.getMonth() != null) {
+            jpql.append("\nAND FUNCTION('MONTH', tr.createdAt) = :month)");
+        }
+        if(condition.getAccountId()!=null){
+            jpql.append("\nAND u.accountId = :accountId");
+        }
+
+        return jpql.toString();
+    }
+}

--- a/NBTI/src/main/java/com/dao/nbti/test/domain/repository/TestResultRepository.java
+++ b/NBTI/src/main/java/com/dao/nbti/test/domain/repository/TestResultRepository.java
@@ -43,4 +43,5 @@ public interface TestResultRepository extends JpaRepository<TestResult, Integer>
     """, nativeQuery = true)
     Optional<TestResult> findLatestByUserId(@Param("userId") int userId);
 
+    Optional<TestResult> findByTestResultId(int testResultId);
 }


### PR DESCRIPTION
closes #45
closes #46 

---

📌 개요
또 커밋 번호 잘못 적었네요...
관리자는 사용자의 검사 목록을 조회할 수 있다.
검사 목록 조회 시 사용자 accountId, 년월을 필터링 할 수 있다.

🔨 주요 변경 사항
TestResultController 및 TestResultService에 메소드 추가
TestRepositoryCustom 및 TestRepositoryCustomImpl 구현

✅ 리뷰 요청 사항
검사 목록 조회 로직 검토

⭐ 관련 이슈
#45
